### PR TITLE
chore: put amd sbom generation in separate workflow

### DIFF
--- a/.github/workflows/amd-image-sbom.yml
+++ b/.github/workflows/amd-image-sbom.yml
@@ -1,0 +1,61 @@
+name: amd-image-sbom
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      image-tag:
+        required: true
+        type: string
+    secrets:
+      registry-token:
+        required: true
+
+jobs:
+  amd-image-sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@main
+
+      - name: Login to Quay
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io/triton-dev-containers
+          username: ${{ secrets.qt_username }}
+          password: ${{ secrets.qt_password }}
+
+      - name: Generate SBOM
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: anchore/sbom-action@v0.18.0
+        with:
+          image: quay.io/triton-dev-containers/amd:${{ inputs.image-tag }}
+          artifact-name: sbom-amd-${{ inputs.image-tag }}.json
+          output-file: ./sbom-amd-${{ inputs.image-tag }}.spdx.json
+
+      - name: Generate SBOM attestation with Cosign
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          cosign attest -y --predicate ./sbom-amd-${{ inputs.image-tag }}.spdx.json quay.io/triton-dev-containers/amd:${{ inputs.image-tag }}
+
+      - name: Compress SBOM
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: gzip ./sbom-amd-${{ inputs.image-tag }}.spdx.json
+
+      - name: Save SBOM as artifact
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-amd-${{ inputs.image-tag }}.spdx.json.gz
+          path: ./sbom-amd-${{ inputs.image-tag }}.spdx.json.gz
+          retention-days: 1

--- a/.github/workflows/amd-image.yml
+++ b/.github/workflows/amd-image.yml
@@ -1,6 +1,6 @@
 name: amd-image
 
-on: # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - main
@@ -38,9 +38,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # NOTE:  setting fetch-depth to 0 to retrieve the entire history
-          # instead of a shallow-clone so that all tags are fetched as well.
-          # This is necessary for computing the VERSION using `git describe`
           fetch-depth: 0
 
       - name: Set up QEMU
@@ -71,7 +68,7 @@ jobs:
           push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           tags: quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}
           labels: ${{ matrix.LABEL }}
-          build-args: ${{matrix.BUILD_ARGS}}
+          build-args: ${{ matrix.BUILD_ARGS }}
           file: ${{ matrix.IMAGE_FILE }}
 
       - name: Sign images with GitHub OIDC Token
@@ -80,35 +77,17 @@ jobs:
           cosign sign -y quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}@${{ steps.build-push-image.outputs.digest }}
 
       - name: Generate image attestation
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}
           subject-digest: ${{ steps.build-push-image.outputs.digest }}
           push-to-registry: true
 
-      # - name: Generate SBOM
-      #   if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      #   uses: anchore/sbom-action@v0.18.0
-      #   with:
-      #     image: quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}
-      #     artifact-name: sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.json
-      #     output-file: ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json
-
-      # - name: Generate SBOM attestation with Cosign with GitHub OIDC Token
-      #   if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      #   run: |
-      #     cosign attest -y --predicate ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}@${{ steps.build-push-image.outputs.digest }}
-
-      # - name: Compress SBOM
-      # if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      #   run: gzip ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json
-
-      # - name: Save Triton-amd image SBOM as artifact
-      #   if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      #   uses: actions/upload-artifact@v4.6.0
-      #   with:
-      #     name: sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json.gz
-      #     path: ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json.gz
-      #     retention-days: 1
+  amd-image-sbom:
+    needs: amd-image_build  # Ensures SBOM is generated after the image build
+    uses: ./.github/workflows/amd-image-sbom.yml
+    with:
+      image-tag: "latest"
+    secrets:
+      registry-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes https://github.com/redhat-et/triton-dev-containers/issues/25