### PR TITLE
chore: improve doc structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo provides 2 different flavours of development containers:
 
 - **Docker** or **Podman**
 - **NVIDIA Container Toolkit for GPU Usage**
+- **AMD ROCm for GPU Usage**
 
 > **_NOTE_**: If you are using an NVIDIA GPU, you also need to complete the steps
   to install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
@@ -26,16 +27,15 @@ This repo provides 2 different flavours of development containers:
 
 - NVIDIA GPUs
 - CPUs
+- AMD GPUs
 
-> **_NOTE_**: Support for AMD GPU devcontainers will be added soon.
-
-## Building the triton vanilla container
+## Building the triton NVIDIA vanilla container
 
 ```sh
  make triton-image
 ```
 
-## Running the triton vanilla container
+## Running the triton NVIDIA vanilla container
 
 ```sh
  make triton-run [triton_path=<path-to-triton-on-host>]
@@ -95,99 +95,12 @@ Please see the [.devcontainer user guide](./.devcontainer/devcontainer.md)
 
 ## Demos
 
-- [Triton devcontainer vscode demo](https://www.youtube.com/watch?v=ZrCVtV2Bw3s)
-- [Triton devcontainer demo](https://www.youtube.com/watch?v=kEbN6-pk3sI)
+To see the VSCODE devcontainers in action please check out the
+[Triton devcontainer vscode demo](https://www.youtube.com/watch?v=ZrCVtV2Bw3s)
 
-## A Container First approach to Triton development
+To see the vanilla development containers in action please checkout the
+[Triton devcontainer demo](https://www.youtube.com/watch?v=kEbN6-pk3sI)
 
-The Triton project from OpenAI is at the forefront of a groundbreaking movement
-to [democratize AI accelerators and GPU kernel programming](https://next.redhat.com/2024/11/07/democratizing-ai-accelerators-and-gpu-kernel-programming-using-triton/).
-By providing a flexible, efficient, and accessible framework for developing
-custom GPU kernels, Triton empowers developers to push the boundaries of AI
-performance. In this blog, we’ll explore a container-first development
-approach that enhances the Triton development workflow. This approach
-streamlines the development, testing, and deployment of models, enabling
-faster iteration and more efficient model optimization greatly
-benefiting the Triton development workflow and improving the Triton
-developer experience.
+## Why Container-First Development Matters?
 
-### Why Container-First Development Matters?
-
-AI’s rapid evolution demands cutting-edge development practices to deliver
-highly optimised solutions. For teams working on AI models, container-first
-development offers a streamlined workflow, enhanced collaboration, and
-consistent results across diverse environments. Let’s explore how adopting
-this strategy benefits Triton projects.
-
-### What is container first development?
-
-A container-first approach prioritises using containerization technologies
-like Docker or Podman throughout the software development lifecycle.
-Containers bundle an application with its dependencies, configurations,
-and runtime environment into a lightweight, portable unit. This guarantees
-consistent behavior across various environments—from a developer’s laptop
-to staging servers to production. For Triton, where consistency and
-efficiency are paramount, containers are an ideal fit, ensuring
-predictable performance with minimal overhead.
-
-### Benefits of Container First Development for Triton
-
-- **Compile Once Run Anywhere**: Containers offer consistency across
-environments. This reduces debugging time, enhances confidence in code
-quality, and improves CI/CD pipeline reliability.
-- **Streamlined Developer Onboarding**: Onboarding new developers can
-be challenging due to inconsistent development environments.
-Pre-configured container images eliminate this hurdle, enabling
-developers to start working immediately without complex setup
-processes.
-- **Improved Collaboration**: AI projects often involve diverse
-teams—data scientists, DevOps engineers, and developers.
-Containers act as a common denominator, enabling seamless
-collaboration by standardizing tools and libraries within a
-single image that can be shared across teams.
-- **Enhanced Security**:
-  - Containers can use minimal base images, reducing the attack surface.
-  - Dockerfiles can generate Software Bills of Materials (SBOMs), helping
-    track dependencies and identify vulnerabilities quickly.
-  - Security mechanisms like image signing ensure authenticity and
-    integrity, reducing risks from malicious images while bolstering trust
-    in the software supply chain.
-
-### Triton Container First Development
-
-Currently, Triton development workflows are not fully container-centric.
-Developers often begin by cloning the GitHub project and manually
-installing all required dependencies on their local machine or
-development server. This process can be time-consuming and error-prone,
-often resulting in issues such as:
-
-- **Time-Intensive Setup**: Manually configuring environments takes valuable
-  time that could be spent on actual development work.
-- **System Configuration Disparities**: Differences in local environments can
-  introduce subtle bugs that are difficult to reproduce and resolve.
-- **Insufficient Documentation**: Incomplete or unclear instructions can slow
-  developers down as they troubleshoot setup problems.
-- **Dependency Conflicts**
-
-A [pull request](https://github.com/triton-lang/triton/pull/5143) to add a
-[Development Container](https://containers.dev/) with all the tools needed to
-build and run the Triton project was created in late 2024, it’s hoped that this
-will be adopted by the project as it’s a good start towards enabling a
-container centric development approach for Triton. This is also being further
-developed to support development environments that are not ‘Visual Studio Code’
-centric via a github repository and a quay.io image repository to host the
-development container images.
-
-### Conclusion
-
-A container-first approach to software development empowers Triton projects with
-agility, consistency, and scalability. By isolating dependencies, standardizing
-environments, and facilitating seamless collaboration, this approach addresses
-many traditional pain points in software development workflows. As the Triton
-ecosystem continues to grow and evolve, integrating a container-first mindset
-will not only enhance productivity but also ensure that the projects remain
-robust, secure, and ready for the future.
-
-### References
-
-- [5 Benefits of a Container-First Approach to Software Development | Docker](https://www.docker.com/blog/5-benefits-of-a-container-first-approach-to-software-development/)
+Please checkout why container-first development matters [here](./docs/ContainerFirstDevelopment.md)

--- a/docs/ContainerFirstDevelopment.md
+++ b/docs/ContainerFirstDevelopment.md
@@ -1,0 +1,93 @@
+# A Container First approach to Triton development
+
+The Triton project from OpenAI is at the forefront of a groundbreaking movement
+to [democratize AI accelerators and GPU kernel programming](https://next.redhat.com/2024/11/07/democratizing-ai-accelerators-and-gpu-kernel-programming-using-triton/).
+By providing a flexible, efficient, and accessible framework for developing
+custom GPU kernels, Triton empowers developers to push the boundaries of AI
+performance. In this blog, we’ll explore a container-first development
+approach that enhances the Triton development workflow. This approach
+streamlines the development, testing, and deployment of models, enabling
+faster iteration and more efficient model optimization greatly
+benefiting the Triton development workflow and improving the Triton
+developer experience.
+
+## Why Container-First Development Matters?
+
+AI’s rapid evolution demands cutting-edge development practices to deliver
+highly optimised solutions. For teams working on AI models, container-first
+development offers a streamlined workflow, enhanced collaboration, and
+consistent results across diverse environments. Let’s explore how adopting
+this strategy benefits Triton projects.
+
+## What is container first development?
+
+A container-first approach prioritises using containerization technologies
+like Docker or Podman throughout the software development lifecycle.
+Containers bundle an application with its dependencies, configurations,
+and runtime environment into a lightweight, portable unit. This guarantees
+consistent behavior across various environments—from a developer’s laptop
+to staging servers to production. For Triton, where consistency and
+efficiency are paramount, containers are an ideal fit, ensuring
+predictable performance with minimal overhead.
+
+## Benefits of Container First Development for Triton
+
+- **Compile Once Run Anywhere**: Containers offer consistency across
+environments. This reduces debugging time, enhances confidence in code
+quality, and improves CI/CD pipeline reliability.
+- **Streamlined Developer Onboarding**: Onboarding new developers can
+be challenging due to inconsistent development environments.
+Pre-configured container images eliminate this hurdle, enabling
+developers to start working immediately without complex setup
+processes.
+- **Improved Collaboration**: AI projects often involve diverse
+teams—data scientists, DevOps engineers, and developers.
+Containers act as a common denominator, enabling seamless
+collaboration by standardizing tools and libraries within a
+single image that can be shared across teams.
+- **Enhanced Security**:
+  - Containers can use minimal base images, reducing the attack surface.
+  - Dockerfiles can generate Software Bills of Materials (SBOMs), helping
+    track dependencies and identify vulnerabilities quickly.
+  - Security mechanisms like image signing ensure authenticity and
+    integrity, reducing risks from malicious images while bolstering trust
+    in the software supply chain.
+
+## Triton Container First Development
+
+Currently, Triton development workflows are not fully container-centric.
+Developers often begin by cloning the GitHub project and manually
+installing all required dependencies on their local machine or
+development server. This process can be time-consuming and error-prone,
+often resulting in issues such as:
+
+- **Time-Intensive Setup**: Manually configuring environments takes valuable
+  time that could be spent on actual development work.
+- **System Configuration Disparities**: Differences in local environments can
+  introduce subtle bugs that are difficult to reproduce and resolve.
+- **Insufficient Documentation**: Incomplete or unclear instructions can slow
+  developers down as they troubleshoot setup problems.
+- **Dependency Conflicts**
+
+A [pull request](https://github.com/triton-lang/triton/pull/5143) to add a
+[Development Container](https://containers.dev/) with all the tools needed to
+build and run the Triton project was created in late 2024, it’s hoped that this
+will be adopted by the project as it’s a good start towards enabling a
+container centric development approach for Triton. This is also being further
+developed to support development environments that are not ‘Visual Studio Code’
+centric via a github repository and a quay.io image repository to host the
+development container images.
+
+## Conclusion
+
+A container-first approach to software development empowers Triton projects with
+agility, consistency, and scalability. By isolating dependencies, standardizing
+environments, and facilitating seamless collaboration, this approach addresses
+many traditional pain points in software development workflows. As the Triton
+ecosystem continues to grow and evolve, integrating a container-first mindset
+will not only enhance productivity but also ensure that the projects remain
+robust, secure, and ready for the future.
+
+## References
+
+- [5 Benefits of a Container-First Approach to Software Development | Docker](https://www.docker.com/blog/5-benefits-of-a-container-first-approach-to-software-development/)


### PR DESCRIPTION
Simplify the readme and move the container first development parts to a separate doc