### PR TITLE
Support SELinux when mounting gitconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ HIP_DEVICES := $(or $(HIP_VISIBLE_DEVICES), 0)
 CTR_CMD := $(or $(shell command -v podman), $(shell command -v docker))
 STRIPPED_CMD := $(shell basename $(CTR_CMD))
 OS := $(shell uname -s)
+SELINUXFLAG := $(shell if [ "$(shell getenforce 1> /dev/null)" == "Enforcing" ]; then echo ":z"; fi)
 
 ##@ Container Build
 .PHONY: image-builder-check
@@ -80,7 +81,7 @@ define run_container
 		volume_arg+=" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro"; \
 	fi; \
 	if [ -f "$(gitconfig_path)" ]; then \
-		gitconfig_arg="-v $(gitconfig_path):/etc/gitconfig"; \
+		gitconfig_arg="-v $(gitconfig_path):/etc/gitconfig$(SELINUXFLAG)"; \
 	else \
 		gitconfig_arg=""; \
 	fi; \


### PR DESCRIPTION
Check if SELinux is Enforcing and if so add ":z" to the gitconfig volume mount.

Fixes #47