### PR TITLE
Fix SELINUX_FLAG shell call to not discard the output from getenforce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ HIP_DEVICES := $(or $(HIP_VISIBLE_DEVICES), 0)
 CTR_CMD := $(or $(shell command -v podman), $(shell command -v docker))
 STRIPPED_CMD := $(shell basename $(CTR_CMD))
 OS := $(shell uname -s)
-SELINUXFLAG := $(shell if [ "$(shell getenforce 1> /dev/null)" == "Enforcing" ]; then echo ":z"; fi)
+SELINUXFLAG := $(shell if [ "$(shell getenforce 2> /dev/null)" == "Enforcing" ]; then echo ":z"; fi)
 
 ##@ Container Build
 .PHONY: image-builder-check


### PR DESCRIPTION
Currently when make triton-run adds the users gitconfig as a volume, it doesn't actually add the ':z' flag for systems with selinux enforcing enabled. The getenforcing call redirects the output to /dev/null. The fallout is the git clone fails causing other errors further down in the entrypoint script since your not left sitting in the triton source directory.