### PR TITLE
Remove redundant INSTALL_CUDNN option

### DIFF
--- a/Dockerfile.triton
+++ b/Dockerfile.triton
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG CUSTOM_LLVM=false
-ARG INSTALL_CUDNN=true
 FROM registry.access.redhat.com/ubi9/ubi:latest AS llvm-build
 ARG CUSTOM_LLVM
 USER 0
@@ -38,7 +37,6 @@ RUN if [ "$CUSTOM_LLVM" = "true" ]; then \
 
 FROM registry.access.redhat.com/ubi9/python-312 AS base
 ARG CUSTOM_LLVM
-ARG INSTALL_CUDNN=true
 
 USER 0
 
@@ -70,7 +68,6 @@ ENV BASH_ENV=/workspace/bin/activate \
     PYTHON_VERSION=3.12 \
     PATH=/workspace/bin:$PATH \
     PYTHONUNBUFFERED=1 \
-    INSTALL_CUDNN=${INSTALL_CUDNN} \
     PIP_PREFIX=/workspace \
     PYTHONPATH=/workspace/lib/python$PYTHON_VERSION/site-packages \
     XDG_CACHE_HOME=/workspace \

--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,9 @@ define run_container
 		gpu_args="--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add=video --cap-add=SYS_PTRACE --ipc=host --env HIP_VISIBLE_DEVICES=$(HIP_DEVICES)"; \
 	elif [ "$(strip $(1))" = "$(NVIDIA_IMAGE_NAME)" ]; then \
 		if command -v nvidia-ctk >/dev/null 2>&1 && nvidia-ctk cdi list | grep -q "nvidia.com/gpu=all"; then \
-			gpu_args="--device nvidia.com/gpu=all --env INSTALL_CUDNN=true"; \
+			gpu_args="--device nvidia.com/gpu=all"; \
 		else \
-			gpu_args="--runtime=nvidia --gpus=all --env INSTALL_CUDNN=true"; \
+			gpu_args="--runtime=nvidia --gpus=all"; \
 		fi; \
                 gpu_args+=" --security-opt label=disable"; \
 	fi; \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,6 @@ TRITON_CPU_BACKEND=${TRITON_CPU_BACKEND:-}
 ROCM_VERSION=${ROCM_VERSION:-}
 TORCH_VERSION=${TORCH_VERSION:-"2.5.1"}
 HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES:-}
-INSTALL_CUDNN=${INSTALL_CUDNN:-}
 CREATE_USER=${CREATE_USER:-false}
 CLONED=0
 export_cmd=""
@@ -119,13 +118,6 @@ EOF
     if [ -n "$CLONED" ] && [ "$CLONED" -eq 1 ]; then
         git submodule init
         git submodule update
-    fi
-
-    if [ -n "$INSTALL_CUDNN" ] && [ "$INSTALL_CUDNN" = "true" ]; then
-        echo "###########################################################################"
-        echo "##################### Installing CUDA dependencies... #####################"
-        echo "###########################################################################"
-        python3 -m pip install nvidia-cudnn-cu12;
     fi
 
     if [ -n "$AMD" ] && [ "$AMD" = "true" ]; then
@@ -239,10 +231,6 @@ export_vars() {
 
     if [ -n "$TRITON_CPU_BACKEND" ]; then
         export_vars+=("TRITON_CPU_BACKEND=$TRITON_CPU_BACKEND")
-    fi
-
-    if [ -n "$INSTALL_CUDNN" ]; then
-        export_vars+=("INSTALL_CUDNN=$INSTALL_CUDNN")
     fi
 
     if [ -n "$AMD" ]; then


### PR DESCRIPTION
Correctly versioned CUDNN packages for the installed version of pytorch is already installed automatically when building for NVIDIA.

Fixes #62