### PR TITLE
Add missing environment variables for running the nsight gui apps to runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ commands.
 make triton-profiling-image
 ```
 
+> **_NOTE_**: if you provide `NSIGHT_GUI=true` the dependencies required to run the gui
+apps will be installed.
+
 #### Running the triton NVIDIA profiling container
 
 ```sh
@@ -142,6 +145,9 @@ at container startup time.
 > **_NOTE_**: if you do provide a triton_path you should run `git submodule init`
 and `git submodule update` on the mounted repo if you haven't already run these
 commands.
+
+> **_NOTE_**: if you provide `NSIGHT_GUI=true` the container will be able to launch
+the `nsys-ui` and `ncu-ui` apps.
 
 ### Using .devcontainers with VSCODE
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,9 @@ TRITON_CPU_BACKEND=${TRITON_CPU_BACKEND:-}
 ROCM_VERSION=${ROCM_VERSION:-}
 TORCH_VERSION=${TORCH_VERSION:-"2.5.1"}
 HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES:-}
+DISPLAY=${DISPLAY:-}
+WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-}
+XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-}
 CREATE_USER=${CREATE_USER:-false}
 CLONED=0
 export_cmd=""
@@ -249,6 +252,18 @@ export_vars() {
         export_vars+=("TORCH_VERSION=$TORCH_VERSION")
     fi
 
+    if [ -n "$DISPLAY" ]; then
+        export_vars+=("DISPLAY=$DISPLAY")
+    fi
+    
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+        export_vars+=("WAYLAND_DISPLAY=$WAYLAND_DISPLAY")
+    fi
+
+    if [ -n "$XDG_RUNTIME_DIR" ]; then
+        export_vars+=("XDG_RUNTIME_DIR=/tmp")
+    fi
+    
     for var in "${export_vars[@]}"; do
         export_cmd+="export $var; "
     done


### PR DESCRIPTION
Although the dependencies are installed into the vanilla profiling image when NSIGHT_GUI is set to true at build, the runtime lacked the means to launch a container that would run the gui apps.