### PR TITLE
chore: standalone llvm build

### DIFF
--- a/.github/workflows/llvm-image.yml
+++ b/.github/workflows/llvm-image.yml
@@ -1,0 +1,119 @@
+name: llvm-image
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/llvm-image.yml
+      - Dockerfile.llvm
+  pull_request:
+    paths:
+      - .github/workflows/llvm-image.yml
+      - Dockerfile.llvm
+  schedule:
+    - cron: '0 0 * * 0' # Runs every Sunday at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  llvm-image_build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - IMAGE_NAME: llvm
+            IMAGE_FILE: Dockerfile.llvm
+            PLATFORMS: linux/amd64
+            LABEL: latest
+            BUILD_ARGS: |
+              CUSTOM_LLVM=true
+              TRITON_CPU_BACKEND=0
+          - IMAGE_NAME: llvm
+            IMAGE_FILE: Dockerfile.llvm
+            PLATFORMS: linux/amd64
+            LABEL: cpu-latest
+            BUILD_ARGS: |
+              CUSTOM_LLVM=true
+              TRITON_CPU_BACKEND=1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # NOTE:  setting fetch-depth to 0 to retrieve the entire history
+          # instead of a shallow-clone so that all tags are fetched as well.
+          # This is necessary for computing the VERSION using `git describe`
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@main
+
+      - name: Login to Quay
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io/triton-dev-containers
+          username: ${{ secrets.qt_username }}
+          password: ${{ secrets.qt_password }}
+
+      - name: Build and (conditionally) push image
+        id: build-push-image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.PLATFORMS }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          tags: quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}
+          labels: ${{ matrix.LABEL }}
+          build-args: ${{matrix.BUILD_ARGS}}
+          file: ${{ matrix.IMAGE_FILE }}
+
+      - name: Sign images with GitHub OIDC Token
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          cosign sign -y quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}@${{ steps.build-push-image.outputs.digest }}
+      - name: Generate image attestation
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-push-image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: anchore/sbom-action@v0.18.0
+        with:
+          image: quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}
+          artifact-name: sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.json
+          output-file: ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json
+
+      - name: Generate SBOM attestation with Cosign with GitHub OIDC Token
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          cosign attest -y --predicate ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json --type spdxjson quay.io/triton-dev-containers/${{ matrix.IMAGE_NAME }}:${{ matrix.LABEL }}@${{ steps.build-push-image.outputs.digest }}
+      - name: Compress SBOM
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: gzip ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json
+
+      - name: Save Triton-llvm image SBOM as artifact
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json.gz
+          path: ./sbom-${{ matrix.IMAGE_NAME }}-${{ matrix.LABEL }}.spdx.json.gz
+          retention-days: 1

--- a/Dockerfile.llvm
+++ b/Dockerfile.llvm
@@ -1,0 +1,50 @@
+ARG CUSTOM_LLVM
+ARG TRITON_CPU_BACKEND=0
+ARG LLVM_TAG
+
+FROM registry.access.redhat.com/ubi9/python-312:latest
+ARG CUSTOM_LLVM
+ARG TRITON_CPU_BACKEND=0
+ARG LLVM_TAG
+USER 0
+
+# Conditionally execute the build based on CUSTOM_LLVM
+RUN if [ "$CUSTOM_LLVM" = "true" ]; then \
+        dnf update -y && \
+        dnf -y install clang rpm-build git ninja-build cmake lld && \
+        dnf clean all && rm -rf /var/cache/dnf && \
+        python3 -m pip install --upgrade pip && \
+        python3 -m pip install --upgrade cmake ninja sccache pybind11 && \
+        if [ ! -d "/llvm-project" ]; then \
+            git clone https://github.com/llvm/llvm-project /llvm-project; \
+        else \
+            cd /llvm-project && git fetch origin; \
+            fi && \
+            cd /llvm-project && \
+            python3 -m pip install -r mlir/python/requirements.txt && \
+            REPO="triton"; \
+            PROJECTS="mlir;llvm"; \
+            if [ "$TRITON_CPU_BACKEND" = "1" ]; then REPO="triton-cpu" PROJECTS="mlir;llvm;lld"; fi; \
+            COMMIT="${LLVM_TAG:-$(curl -s https://raw.githubusercontent.com/triton-lang/$REPO/refs/heads/main/cmake/llvm-hash.txt)}" && \
+            CURRENT_COMMIT=$(git rev-parse HEAD) && \
+            if [ "$CURRENT_COMMIT" != "$COMMIT" ] || [ ! -f "/install/bin/llvm-config" ] || [ ! -d "/install/lib" ]; then \
+                echo "LLVM commit mismatch or missing install. Rebuilding..."; \
+                git checkout $COMMIT && \
+                mkdir -p build && cd build && \
+                cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+                    -DLLVM_ENABLE_ASSERTIONS=ON ../llvm \
+                    -DCMAKE_INSTALL_PREFIX=/install \
+                    -DLLVM_BUILD_UTILS=ON \
+                    -DLLVM_BUILD_TOOLS=ON \
+                    -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+                    -DLLVM_INSTALL_UTILS=ON \
+                    -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
+                    -DLLVM_ENABLE_PROJECTS=$PROJECTS && \
+                ninja check-mlir install; \
+            else \
+                echo "LLVM is already up-to-date. Skipping rebuild."; \
+            fi \
+        else \
+            echo "Skipping LLVM build because CUSTOM_LLVM is not true"; \
+            mkdir -p /install; \
+        fi

--- a/Dockerfile.triton
+++ b/Dockerfile.triton
@@ -14,26 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG CUSTOM_LLVM=false
-FROM registry.access.redhat.com/ubi9/ubi:latest AS llvm-build
-ARG CUSTOM_LLVM
-USER 0
-# Conditionally execute the build based on CUSTOM_LLVM
-RUN if [ "$CUSTOM_LLVM" = "true" ]; then \
-        dnf update -y && \
-        dnf -y install clang rpm-build git ninja-build cmake lld && \
-        dnf clean all && rm -rf /var/cache/dnf && \
-        git clone https://github.com/llvm/llvm-project && \
-        cd llvm-project && \
-        COMMIT=$(curl -s https://raw.githubusercontent.com/triton-lang/triton/refs/heads/main/cmake/llvm-hash.txt) &&\
-        git checkout $COMMIT && \
-        mkdir build && \
-        cd build && \
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON ../llvm -DLLVM_ENABLE_PROJECTS="mlir;llvm" -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" && \
-        ninja; \
-    else \
-        echo "Skipping LLVM build because CUSTOM_LLVM is not true"; \
-        mkdir llvm-project; \
-    fi
 
 FROM registry.access.redhat.com/ubi9/python-312 AS base
 ARG CUSTOM_LLVM
@@ -47,7 +27,7 @@ RUN dnf update -y && \
 
 # Stage for llvm-local-true
 FROM base AS llvm-local-true
-COPY --from=llvm-build /llvm-project/ /llvm-project/
+COPY --from=quay.io/triton-dev-containers/llvm:latest /install /llvm-project/install
 
 # Stage for llvm-local-false
 FROM base AS llvm-local-false

--- a/Dockerfile.triton-amd
+++ b/Dockerfile.triton-amd
@@ -17,27 +17,6 @@
 ARG CUSTOM_LLVM=false
 ARG ROCM_VERSION=6.2
 
-# LLVM Build Stage
-FROM registry.access.redhat.com/ubi9/ubi:latest AS llvm-build
-ARG CUSTOM_LLVM
-USER 0
-RUN if [ "$CUSTOM_LLVM" = "true" ]; then \
-        dnf update -y && \
-        dnf -y install clang rpm-build git ninja-build cmake lld && \
-        git clone https://github.com/llvm/llvm-project && \
-        cd llvm-project && \
-        COMMIT=$(curl -s https://raw.githubusercontent.com/triton-lang/triton/refs/heads/main/cmake/llvm-hash.txt) && \
-        git checkout $COMMIT && \
-        mkdir build && cd build && \
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON ../llvm \
-              -DLLVM_ENABLE_PROJECTS="mlir;llvm" -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" && \
-        ninja && \
-        dnf clean all && rm -rf /var/cache/dnf /tmp/*; \
-    else \
-        echo "Skipping LLVM build because CUSTOM_LLVM is not true"; \
-        mkdir llvm-project; \
-    fi
-
 # Base Stage with ROCm Installation
 FROM registry.access.redhat.com/ubi9/python-311 AS base
 ARG ROCM_VERSION=6.2
@@ -68,7 +47,7 @@ PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:$PATH
 
 # LLVM Integration Stages
 FROM base AS llvm-local-true
-COPY --from=llvm-build /llvm-project/ /llvm-project/
+COPY --from=quay.io/triton-dev-containers/llvm:latest /install /llvm-project/install
 
 FROM base AS llvm-local-false
 ENV TRITON_OFFLINE_BUILD=NO

--- a/Dockerfile.triton-cpu
+++ b/Dockerfile.triton-cpu
@@ -16,27 +16,6 @@
 
 ARG CUSTOM_LLVM=false
 
-FROM registry.access.redhat.com/ubi9/ubi:latest AS llvm-build
-ARG CUSTOM_LLVM
-USER 0
-# Conditionally execute the build based on CUSTOM_LLVM
-RUN if [ "$CUSTOM_LLVM" = "true" ]; then \
-        dnf update -y && \
-        dnf -y install clang rpm-build git ninja-build cmake lld && \
-        dnf clean all && rm -rf /var/cache/dnf && \
-        git clone https://github.com/llvm/llvm-project && \
-        cd llvm-project && \
-        COMMIT=$(curl -s https://raw.githubusercontent.com/triton-lang/triton-cpu/refs/heads/main/cmake/llvm-hash.txt) &&\
-        git checkout $COMMIT && \
-        mkdir build && \
-        cd build && \
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON ../llvm -DLLVM_ENABLE_PROJECTS="mlir;llvm" -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" && \
-        ninja; \
-    else \
-        echo "Skipping LLVM build because CUSTOM_LLVM is not true"; \
-        mkdir llvm-project; \
-    fi
-
 FROM registry.access.redhat.com/ubi9/python-312 AS base
 ARG CUSTOM_LLVM
 
@@ -49,7 +28,7 @@ RUN dnf update -y && \
 
 # Stage for llvm-local-true
 FROM base AS llvm-local-true
-COPY --from=llvm-build /llvm-project/ /llvm-project/
+COPY --from=quay.io/triton-dev-containers/llvm:cpu-latest /install /llvm-project/install
 
 # Stage for llvm-local-false
 FROM base AS llvm-local-false

--- a/Dockerfile.triton-profiling
+++ b/Dockerfile.triton-profiling
@@ -14,26 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG CUSTOM_LLVM=false
-FROM registry.access.redhat.com/ubi9/ubi:latest AS llvm-build
-ARG CUSTOM_LLVM
-USER 0
-# Conditionally execute the build based on CUSTOM_LLVM
-RUN if [ "$CUSTOM_LLVM" = "true" ]; then \
-        dnf update -y && \
-        dnf -y install clang rpm-build git ninja-build cmake lld && \
-        dnf clean all && rm -rf /var/cache/dnf && \
-        git clone https://github.com/llvm/llvm-project && \
-        cd llvm-project && \
-        COMMIT=$(curl -s https://raw.githubusercontent.com/triton-lang/triton/refs/heads/main/cmake/llvm-hash.txt) &&\
-        git checkout $COMMIT && \
-        mkdir build && \
-        cd build && \
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON ../llvm -DLLVM_ENABLE_PROJECTS="mlir;llvm" -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" && \
-        ninja; \
-    else \
-        echo "Skipping LLVM build because CUSTOM_LLVM is not true"; \
-        mkdir llvm-project; \
-    fi
 
 FROM registry.access.redhat.com/ubi9/python-312 AS base
 ARG CUSTOM_LLVM
@@ -58,7 +38,7 @@ RUN dnf -y update && \
 
 # Stage for llvm-local-true
 FROM base AS llvm-local-true
-COPY --from=llvm-build /llvm-project/ /llvm-project/
+COPY --from=quay.io/triton-dev-containers/llvm:cpu-latest /install /llvm-project/install
 
 # Stage for llvm-local-false
 FROM base AS llvm-local-false

--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,12 @@ triton-cpu-image: image-builder-check gosu-image ## Build the Triton CPU image
 		-f Dockerfile.triton-cpu .
 
 .PHONY: triton-amd-image
-triton-amd-image: image-builder-check gosu-image ## Build the Triton AMD devcontainer image
+triton-amd-image: image-builder-check gosu-image llvm-image ## Build the Triton AMD devcontainer image
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(AMD_IMAGE_NAME):$(TRITON_TAG) \
 		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) -f Dockerfile.triton-amd .
 
 .PHONY: triton-profiling-image
-triton-amd-image: image-builder-check gosu-image llvm-image ## Build the Triton AMD devcontainer image
+triton-profiling-image: image-builder-check gosu-image llvm-image ## Build the Triton profiling devcontainer image
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(NVIDIA_PROFILING_IMAGE_NAME):$(TRITON_TAG) \
 		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) --build-arg NSIGHT_GUI=$(NSIGHT_GUI) \
 		-f Dockerfile.triton-profiling .

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ CUSTOM_LLVM ?=false
 DEMO_TOOLS ?= false
 HIP_DEVICES := $(or $(HIP_VISIBLE_DEVICES), 0)
 IMAGE_REPO ?=quay.io/triton-dev-containers
+LLVM_IMAGE_LABEL ?= latest # Need a separate tag so we only update TRITON_TAG for custom builds
+LLVM_TAG ?=
 mkfile_path :=$(abspath $(lastword $(MAKEFILE_LIST)))
 NVIDIA_IMAGE_NAME ?=nvidia
 OS := $(shell uname -s)
@@ -30,6 +32,7 @@ SELINUXFLAG := $(shell if [ "$(shell getenforce 2> /dev/null)" == "Enforcing" ];
 source_dir :=$(shell dirname "$(mkfile_path)")
 STRIPPED_CMD := $(shell basename $(CTR_CMD))
 torch_version ?=$(shell curl -s https://api.github.com/repos/pytorch/pytorch/releases/latest | grep '"tag_name":' | sed -E 's/.*"tag_name": "v?([^\"]+)".*/\1/')
+TRITON_CPU_BACKEND ?=0
 TRITON_TAG ?= latest
 triton_path ?=$(source_dir)
 gitconfig_path ?="$(HOME)/.gitconfig"
@@ -38,6 +41,15 @@ create_user ?=true
 NVIDIA_PROFILING_IMAGE_NAME ?=nvidia-profiling
 # NOTE: Requires host build system to have a valid Red Hat Subscription if true
 NSIGHT_GUI ?= false
+
+# Modify image tag if CUSTOM_LLVM is enabled
+ifeq ($(CUSTOM_LLVM),true)
+    TRITON_TAG := custom-llvm-$(TRITON_TAG)
+endif
+
+ifeq ($(TRITON_CPU_BACKEND),1)
+    LLVM_IMAGE_LABEL := cpu-$(LLVM_IMAGE_LABEL)
+endif
 
 ##@ Container Build
 .PHONY: image-builder-check
@@ -50,19 +62,29 @@ image-builder-check: ## Verify if container runtime is available
 .PHONY: all
 all: triton-image triton-cpu-image triton-amd-image triton-profiling-image
 
+.PHONY: llvm-image
+llvm-image: image-builder-check ## Build the Triton LLVM image
+	$(CTR_CMD) build -t $(IMAGE_REPO)/llvm:$(LLVM_IMAGE_LABEL) \
+		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) \
+		--build-arg LLVM_TAG=$(LLVM_TAG) \
+		--build-arg TRITON_CPU_BACKEND=$(TRITON_CPU_BACKEND) \
+		-f Dockerfile.llvm .
+
 .PHONY: gosu-image
-gosu-image: image-builder-check ## Build the Triton devcontainer image
-	$(CTR_CMD) build -t $(IMAGE_REPO)/gosu:$(TRITON_TAG) -f Dockerfile.gosu .
+gosu-image: image-builder-check ## Build the Triton gosu image
+	$(CTR_CMD) build -t $(IMAGE_REPO)/gosu:latest -f Dockerfile.gosu .
 
 .PHONY: triton-image
-triton-image: image-builder-check gosu-image ## Build the Triton devcontainer image
+triton-image: image-builder-check gosu-image llvm-image ## Build the Triton devcontainer image
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(NVIDIA_IMAGE_NAME):$(TRITON_TAG) \
 		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) -f Dockerfile.triton .
 
 .PHONY: triton-cpu-image
-triton-cpu-image: image-builder-check gosu-image ## Build the Triton CPU devcontainer image
+triton-cpu-image: image-builder-check gosu-image ## Build the Triton CPU image
+	$(MAKE) llvm-image CUSTOM_LLVM=$(CUSTOM_LLVM) TRITON_CPU_BACKEND=1 LLVM_IMAGE_LABEL=cpu-latest
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(CPU_IMAGE_NAME):$(TRITON_TAG) \
-		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) -f Dockerfile.triton-cpu .
+		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) --build-arg TRITON_CPU_BACKEND=1 \
+		-f Dockerfile.triton-cpu .
 
 .PHONY: triton-amd-image
 triton-amd-image: image-builder-check gosu-image ## Build the Triton AMD devcontainer image
@@ -70,7 +92,7 @@ triton-amd-image: image-builder-check gosu-image ## Build the Triton AMD devcont
 		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) -f Dockerfile.triton-amd .
 
 .PHONY: triton-profiling-image
-triton-profiling-image: image-builder-check gosu-image ## Build the Triton devcontainer image
+triton-amd-image: image-builder-check gosu-image llvm-image ## Build the Triton AMD devcontainer image
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(NVIDIA_PROFILING_IMAGE_NAME):$(TRITON_TAG) \
 		--build-arg CUSTOM_LLVM=$(CUSTOM_LLVM) --build-arg NSIGHT_GUI=$(NSIGHT_GUI) \
 		-f Dockerfile.triton-profiling .
@@ -124,18 +146,16 @@ define run_container
 	else \
 		port_arg=""; \
 	fi; \
+	env_vars="-e USERNAME=$(USER) -e TORCH_VERSION=$(torch_version) -e CUSTOM_LLVM=$(CUSTOM_LLVM)" -e DEMO_TOOLS=$(DEMO_TOOLS); \
 	if [ "$(create_user)" = "true" ]; then \
-		$(CTR_CMD) run -e CREATE_USER=$(create_user) -e USERNAME=$(USER) \
-		-e TORCH_VERSION=$(torch_version) -e DEMO_TOOLS=$(DEMO_TOOLS) $$port_arg \
+		$(CTR_CMD) run -e CREATE_USER=$(create_user) $$env_vars $$port_arg \
 		-e USER_UID=`id -u $(USER)` -e USER_GID=`id -g $(USER)` $$gpu_args $$profiling_args $$keep_ns_arg \
 		-ti $$volume_arg $$gitconfig_arg $(IMAGE_REPO)/$(strip $(1)):$(TRITON_TAG) bash; \
 	elif [ "$(STRIPPED_CMD)" = "docker" ]; then \
-		$(CTR_CMD) run --user $(shell id -u):$(shell id -g) -e USERNAME=$(USER) $$gpu_args $$profiling_args \
-		-e TORCH_VERSION=$(torch_version) -e DEMO_TOOLS=$(DEMO_TOOLS) $$port_arg \
+		$(CTR_CMD) run --user $(shell id -u):$(shell id -g) $$env_vars $$gpu_args $$profiling_args $$port_arg \
 		-ti $$volume_arg $$gitconfig_arg $(IMAGE_REPO)/$(strip $(1)):$(TRITON_TAG) bash; \
 	elif [ "$(STRIPPED_CMD)" = "podman" ]; then \
-		$(CTR_CMD) run --user $(USER) -e USERNAME=$(USER) $$keep_ns_arg $$gpu_args $$profiling_args \
-		-e TORCH_VERSION=$(torch_version) -e DEMO_TOOLS=$(DEMO_TOOLS) $$port_arg \
+		$(CTR_CMD) run --user $(USER) $$env_vars $$keep_ns_arg $$gpu_args $$profiling_args $$port_arg \
 		-ti $$volume_arg $$gitconfig_arg $(IMAGE_REPO)/$(strip $(1)):$(TRITON_TAG) bash; \
 	fi
 endef

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ commands.
 > **_NOTE_**: if you provide `NSIGHT_GUI=true` the container will be able to launch
 the `nsys-ui` and `ncu-ui` apps.
 
+### Building the vanilla/profiling containers with custom LLVM
+
+```sh
+ make CUSTOM_LLVM=true [triton-image | triton-amd-image | triton-profiling-image ]
+```
+
+> **_NOTE_**: this command will use the commit in `llvm-hash.txt` from the relevant
+Triton repo.
+> To use a specific tag also use LLVM_TAG=<commit-id>
+
 ### Using .devcontainers with VSCODE
 
 Please see the [.devcontainer user guide](./.devcontainer/devcontainer.md)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -162,19 +162,23 @@ EOF
         echo "################################################################"
         echo "##################### CUSTOM LLVM BUILD... #####################"
         echo "################################################################"
-        echo "export LLVM_BUILD_DIR=/llvm-project/build " >> "${HOME}/.bashrc" && \
-        echo "export LLVM_INCLUDE_DIRS=/llvm-project/build/include" >> "${HOME}/.bashrc" && \
-        echo "export LLVM_LIBRARY_DIR=/llvm-project/build/lib" >> "${HOME}/.bashrc" && \
-        echo "export LLVM_SYSPATH=/llvm-project/build" >> "${HOME}/.bashrc";
-        declare -a llvm_vars=(
-            "LLVM_BUILD_DIR=/llvm-project/build"
-            "LLVM_INCLUDE_DIRS=/llvm-project/build/include"
-            "LLVM_LIBRARY_DIR=/llvm-project/build/lib"
-            "LLVM_SYSPATH=/llvm-project/build"
-        )
-        for var in "${llvm_vars[@]}"; do
-            export var
-        done
+        if [ -d "/llvm-project/install/bin" ]; then
+            echo "export LLVM_BUILD_DIR=/llvm-project/install " >> "${HOME}/.bashrc" && \
+            echo "export LLVM_INCLUDE_DIRS=/llvm-project/install/include" >> "${HOME}/.bashrc" && \
+            echo "export LLVM_LIBRARY_DIR=/llvm-project/install/lib" >> "${HOME}/.bashrc" && \
+            echo "export LLVM_SYSPATH=/llvm-project/install" >> "${HOME}/.bashrc";
+            declare -a llvm_vars=(
+                "LLVM_BUILD_DIR=/llvm-project/install"
+                "LLVM_INCLUDE_DIRS=/llvm-project/install/include"
+                "LLVM_LIBRARY_DIR=/llvm-project/install/lib"
+                "LLVM_SYSPATH=/llvm-project/install"
+            )
+            for var in "${llvm_vars[@]}"; do
+                export var
+            done
+        else
+            echo "ERROR /llvm-project/install is empty skipping this step"
+        fi
     fi
 }
 


### PR DESCRIPTION
- [x] Move the LLVM build stage (out of the individual containers) to its own dockerfile. 
- [x] Update the documentation
- [x] Add a github workflow to build the custom llvm container.

Fixes https://github.com/redhat-et/triton-dev-containers/issues/28