### PR TITLE
Lean CUSTOM_LLVM build

### DIFF
--- a/Dockerfile.llvm
+++ b/Dockerfile.llvm
@@ -19,32 +19,54 @@ RUN if [ "$CUSTOM_LLVM" = "true" ]; then \
             git clone https://github.com/llvm/llvm-project /llvm-project; \
         else \
             cd /llvm-project && git fetch origin; \
-            fi && \
-            cd /llvm-project && \
-            python3 -m pip install -r mlir/python/requirements.txt && \
-            REPO="triton"; \
-            PROJECTS="mlir;llvm"; \
-            if [ "$TRITON_CPU_BACKEND" = "1" ]; then REPO="triton-cpu" PROJECTS="mlir;llvm;lld"; fi; \
-            COMMIT="${LLVM_TAG:-$(curl -s https://raw.githubusercontent.com/triton-lang/$REPO/refs/heads/main/cmake/llvm-hash.txt)}" && \
-            CURRENT_COMMIT=$(git rev-parse HEAD) && \
-            if [ "$CURRENT_COMMIT" != "$COMMIT" ] || [ ! -f "/install/bin/llvm-config" ] || [ ! -d "/install/lib" ]; then \
-                echo "LLVM commit mismatch or missing install. Rebuilding..."; \
-                git checkout $COMMIT && \
-                mkdir -p build && cd build && \
-                cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
-                    -DLLVM_ENABLE_ASSERTIONS=ON ../llvm \
-                    -DCMAKE_INSTALL_PREFIX=/install \
-                    -DLLVM_BUILD_UTILS=ON \
-                    -DLLVM_BUILD_TOOLS=ON \
-                    -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-                    -DLLVM_INSTALL_UTILS=ON \
-                    -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
-                    -DLLVM_ENABLE_PROJECTS=$PROJECTS && \
-                ninja check-mlir install; \
-            else \
-                echo "LLVM is already up-to-date. Skipping rebuild."; \
-            fi \
+        fi && \
+        cd /llvm-project && \
+        python3 -m pip install -r mlir/python/requirements.txt && \
+        REPO="triton"; \
+        PROJECTS="mlir;llvm"; \
+        if [ "$TRITON_CPU_BACKEND" = "1" ]; then REPO="triton-cpu" PROJECTS="mlir;llvm;lld"; fi; \
+        COMMIT="${LLVM_TAG:-$(curl -s https://raw.githubusercontent.com/triton-lang/$REPO/refs/heads/main/cmake/llvm-hash.txt)}" && \
+        CURRENT_COMMIT=$(git rev-parse HEAD) && \
+        if [ "$CURRENT_COMMIT" != "$COMMIT" ] || [ ! -f "/install/bin/llvm-config" ] || [ ! -d "/install/lib" ]; then \
+            echo "LLVM commit mismatch or missing install. Rebuilding..."; \
+            git checkout $COMMIT && \
+            mkdir -p build && cd build && \
+            cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+                -DLLVM_ENABLE_ASSERTIONS=ON ../llvm \
+                -DCMAKE_INSTALL_PREFIX=/install \
+                -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+                -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
+                -DLLVM_ENABLE_PROJECTS=$PROJECTS \
+                -DLLVM_ENABLE_LIBCXX:BOOL=OFF \
+                -DLLVM_ENABLE_ZLIB:BOOL=ON \
+                -DLLVM_ENABLE_FFI:BOOL=ON \
+                -DLLVM_ENABLE_RTTI:BOOL=ON \
+                -DLLVM_BUILD_RUNTIME:BOOL=ON \
+                -DLLVM_BUILD_TOOLS:BOOL=OFF \
+                -DLLVM_INCLUDE_TOOLS:BOOL=ON \
+                -DLLVM_INCLUDE_TESTS:BOOL=OFF \
+                -DLLVM_BUILD_TESTS:BOOL=OFF \
+                -DLLVM_INSTALL_GTEST:BOOL=OFF \
+                -DLLVM_LIT_ARGS=-v \
+                -DLLVM_INCLUDE_EXAMPLES:BOOL=OFF \
+                -DLLVM_BUILD_EXAMPLES:BOOL=OFF \
+                -DLLVM_INCLUDE_UTILS:BOOL=OFF \
+                -DLLVM_INSTALL_UTILS:BOOL=OFF \
+                -DLLVM_INCLUDE_DOCS:BOOL=OFF \
+                -DLLVM_BUILD_DOCS:BOOL=OFF \
+                -DLLVM_ENABLE_SPHINX:BOOL=OFF \
+                -DLLVM_ENABLE_DOXYGEN:BOOL=OFF \
+                -DLLVM_UNREACHABLE_OPTIMIZE:BOOL=OFF \
+                -DLLVM_BUILD_LLVM_DYLIB:BOOL=OFF \
+                -DLLVM_LINK_LLVM_DYLIB:BOOL=OFF \
+                -DLLVM_INSTALL_TOOLCHAIN_ONLY:BOOL=OFF \
+                -DLLVM_INCLUDE_BENCHMARKS=OFF \
+                -DMLIR_ENABLE_EXECUTION_ENGINE:bool=OFF && \
+            ninja install; \
         else \
-            echo "Skipping LLVM build because CUSTOM_LLVM is not true"; \
-            mkdir -p /install; \
-        fi
+            echo "LLVM is already up-to-date. Skipping rebuild."; \
+        fi \
+    else \
+        echo "Skipping LLVM build because CUSTOM_LLVM is not true"; \
+        mkdir -p /install; \
+    fi


### PR DESCRIPTION
Triton only needs a small subset of all of LLVM.  Reduce build time and image size by disabling unused parts of LLVM.

This reduces the image size by about 3GB.