### PR TITLE
chore: move amd image to python 3.12

### DIFF
--- a/Dockerfile.triton-amd
+++ b/Dockerfile.triton-amd
@@ -18,7 +18,7 @@ ARG CUSTOM_LLVM=false
 ARG ROCM_VERSION=6.2
 
 # Base Stage with ROCm Installation
-FROM registry.access.redhat.com/ubi9/python-311 AS base
+FROM registry.access.redhat.com/ubi9/python-312 AS base
 ARG ROCM_VERSION=6.2
 USER 0
 


### PR DESCRIPTION
Move the amd image from python 3.11 to 3.12