### PR TITLE
Added pypi dep for proton-viewer

### DIFF
--- a/dockerfiles/entrypoint.sh
+++ b/dockerfiles/entrypoint.sh
@@ -183,6 +183,11 @@ EOF
     pip install tabulate scipy ninja cmake wheel pybind11 pytest
     pip install numpy pyyaml ctypeslib2 matplotlib pandas
 
+    echo "####################################################################################"
+    echo "##################### Installing Triton Proton dependencies... #####################"
+    echo "####################################################################################"
+    pip install llnl-hatchet
+
     if [ -n "$CLONED" ] && [ "$CLONED" -eq 1 ]; then
         echo "###############################################################################"
         echo "#####################Installing pre-commit dependencies...#####################"


### PR DESCRIPTION
Adding this dependency allows the proton-viewer to work. No changes were required to use proton to profile a triton kernel.