### PR TITLE
Fix for navigate bug created when user_path was added

### DIFF
--- a/dockerfiles/entrypoint.sh
+++ b/dockerfiles/entrypoint.sh
@@ -65,14 +65,6 @@ chdir_workspace() {
     fi
     cd "$WORKSPACE" || exit 1
 }
-    if [ -d "/workspace/user" ]; then
-        export WORKSPACE="/workspace/user"
-    else
-        export WORKSPACE=$TRITON_DIR
-    fi
-
-    cd "$WORKSPACE" || exit 1
-}
 
 install_system_dependencies() {
     if [ "$INSTALL_NSIGHT" = "true" ]; then


### PR DESCRIPTION
Missed that the install_system_dependencies function in the entrypoint script navigates to the workspace directory and then performs additional installation, i.e. pre-commit install. This is currently being performed in the user_path when one is specified. Separated out navigate into two functions, one that changes to the workspace directory and another that changes to the triton source directory.