### PR TITLE
feat: add CLI wrapper script for container management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ INSTALL_JUPYTER ?= true
 INSTALL_LLVM   ?= skip              # [ source | skip ]
 INSTALL_HELION ?= skip              # [ source | release | nightly | skip ]
 INSTALL_TORCH  ?= skip              # [ source | release | nightly | test | skip ]
-INSTALL_TRITON ?= source            # [ source | release | skip ]
+INSTALL_TRITON ?= skip              # [ source | release | skip ]
 INSTALL_VLLM   ?= skip              # [ source | release | nightly | skip ]
 
 # Framework versions to install from PyPi (latest is default for Torch)
@@ -191,102 +191,106 @@ rocm-image: dockerfiles/Dockerfile.rocm | base-image ## Build a ROCm container i
 		--build-arg BUILD_ROCM_RHEL_VERSION=$(ROCM_RHEL_VERSION),$<)
 
 ##@ Container Run
-# If you are on an OS that has the user in /etc/passwd then we can pass
-# the user from the host to the pod. Otherwise we default to create the
-# user inside the container.
-# With podman if you aren't creating the user you need to explicitly pass
-# the user as --user $(USER) to start the container as that user.
-define run_container
-	echo "Running container image: $(IMAGE_REPO)/$(strip $(1)):$(2) with $(CTR_CMD)"
-	@if [ "$(triton_path)" != "$(source_dir)" ]; then \
-		volume_arg="-v $(triton_path):/workspace/$(strip $(3))$(SELINUXFLAG)"; \
-	else \
-		volume_arg=""; \
-	fi; \
-	if [ -n "$(llvm_path)" ]; then \
-		if [ -d "$(llvm_path)" ]; then \
-			volume_arg+=" -v $(llvm_path):/workspace/llvm-project$(SELINUXFLAG)"; \
-		else \
-			echo "ERROR: llvm_path does not exist: $(llvm_path)" >&2; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ -n "$(torch_path)" ]; then \
-		if [ -d "$(torch_path)" ]; then \
-			volume_arg+=" -v $(torch_path):/workspace/torch$(SELINUXFLAG)"; \
-		else \
-			echo "ERROR: torch_path does not exist: $(torch_path)" >&2; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ -n "$(helion_path)" ]; then \
-		if [ -d "$(helion_path)" ]; then \
-			volume_arg+=" -v $(helion_path):/workspace/helion$(SELINUXFLAG)"; \
-		else \
-			echo "ERROR: helion_path does not exist: $(helion_path)" >&2; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ -n "$(vllm_path)" ]; then \
-		if [ -d "$(vllm_path)" ]; then \
-			volume_arg+=" -v $(vllm_path):/workspace/vllm$(SELINUXFLAG)"; \
-		else \
-			echo "ERROR: vllm_path does not exist: $(vllm_path)" >&2; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ -n "$(user_path)" ]; then \
-		if [ -d "$(user_path)" ]; then \
-			volume_arg+=" -v $(user_path):/workspace/user$(SELINUXFLAG)"; \
-		else \
-			echo "ERROR: user_path does not exist: $(user_path)" >&2; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ "$(OS)" != "Darwin" ] && ! getent passwd $(USER) > /dev/null; then \
-		volume_arg+=" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro"; \
-	fi; \
-	if [ -f "$(gitconfig_path)" ]; then \
-		gitconfig_arg="-v $(gitconfig_path):/etc/gitconfig$(SELINUXFLAG)"; \
-	else \
-		gitconfig_arg=""; \
-	fi; \
-	if [ "$(strip $(1))" = "$(ROCM_IMAGE_NAME)" ]; then \
-		gpu_args="--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add=video --cap-add=SYS_PTRACE --ipc=host --env HIP_VISIBLE_DEVICES=$(HIP_DEVICES)"; \
-	elif [ "$(strip $(1))" = "$(CUDA_IMAGE_NAME)" ]; then \
-		if command -v nvidia-ctk >/dev/null 2>&1 && nvidia-ctk cdi list | grep -q "nvidia.com/gpu=all"; then \
-			gpu_args="--device nvidia.com/gpu=all"; \
-		else \
-			gpu_args="--runtime=nvidia --gpus=all"; \
-		fi; \
-		gpu_args+=" --security-opt label=disable"; \
-		if [ "$(INSTALL_NSIGHT)" = "true" ]; then \
-			profiling_args="--privileged --cap-add=SYS_ADMIN -e INSTALL_NSIGHT=${INSTALL_NSIGHT} -e DISPLAY=${DISPLAY} -e WAYLAND_DISPLAY=${WAYLAND_DISPLAY} -e XDG_RUNTIME_DIR=/tmp -v ${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:/tmp/${WAYLAND_DISPLAY}:ro"; \
-		else \
-			profiling_args=""; \
-		fi; \
-	else \
-		profiling_args=""; \
-	fi; \
-	if [ "$(STRIPPED_CMD)" = "podman" ]; then \
-		keep_ns_arg="--userns=keep-id"; \
-	else \
-		keep_ns_arg=""; \
-	fi; \
-	if [ "$(INSTALL_JUPYTER)" = "true" ]; then \
-		port_arg="-p ${NOTEBOOK_PORT}:${NOTEBOOK_PORT}"; \
-	else \
-		port_arg=""; \
-	fi; \
-	env_vars="-e USERNAME=$(USER) -e USER_UID=`id -u $(USER)` -e USER_GID=`id -g $(USER)` -e INSTALL_LLVM=$(INSTALL_LLVM) -e INSTALL_TOOLS=$(INSTALL_TOOLS) -e INSTALL_JUPYTER=$(INSTALL_JUPYTER) -e NOTEBOOK_PORT=$(NOTEBOOK_PORT) -e INSTALL_HELION=$(INSTALL_HELION) -e INSTALL_TORCH=$(INSTALL_TORCH) -e INSTALL_TRITON=$(INSTALL_TRITON) -e INSTALL_VLLM=$(INSTALL_VLLM) -e USE_CCACHE=$(USE_CCACHE) -e MAX_JOBS=$(MAX_JOBS)"; \
-	if [ "$(STRIPPED_CMD)" = "docker" ]; then \
-		$(CTR_CMD) run $$env_vars $$gpu_args $$profiling_args $$port_arg \
-		-ti $$volume_arg $$gitconfig_arg $(IMAGE_REPO)/$(strip $(1)):$(2) bash; \
-	elif [ "$(STRIPPED_CMD)" = "podman" ]; then \
-		$(CTR_CMD) run $$env_vars $$keep_ns_arg $$gpu_args $$profiling_args $$port_arg \
-		-ti $$volume_arg $$gitconfig_arg $(IMAGE_REPO)/$(strip $(1)):$(2) bash; \
-	fi
+RUNTIME_ARGS := -t $(IMAGE_TAG) -p $(NOTEBOOK_PORT) -j $(MAX_JOBS)
+
+ifneq ($(llvm_path), )
+	RUNTIME_ARGS += -s LLVM=$(llvm_path)
+endif
+
+ifneq ($(helion_path), )
+	RUNTIME_ARGS += -s HELION=$(helion_path)
+endif
+
+ifneq ($(torch_path), )
+	RUNTIME_ARGS += -s TORCH=$(torch_path)
+endif
+
+ifneq ($(triton_path),$(source_dir))
+	RUNTIME_ARGS += -s TRITON=$(triton_path)
+endif
+
+ifneq ($(user_path), )
+	RUNTIME_ARGS += -s USER=$(user_path)
+endif
+
+ifneq ($(vllm_path), )
+	RUNTIME_ARGS += -s VLLM=$(vllm_path)
+endif
+
+ifneq ($(gitconfig_path), )
+	RUNTIME_ARGS += -s GITCONFIG=$(gitconfig_path)
+endif
+
+ifeq ($(INSTALL_JUPYTER),true)
+	RUNTIME_ARGS += -o INSTALL_JUPYTER=true
+endif
+
+ifeq ($(INSTALL_NSIGHT),true)
+	INSTALL_TOOLS = true
+endif
+
+ifeq ($(INSTALL_TOOLS),true)
+	RUNTIME_ARGS += -o INSTALL_TOOLS=true
+endif
+
+ifneq ($(PIP_HELION_VERSION), )
+	RUNTIME_ARGS += -o PIP_HELION_VERSION=$(PIP_HELION_VERSION)
+endif
+
+ifneq ($(PIP_TORCH_VERSION), )
+	RUNTIME_ARGS += -o PIP_TORCH_VERSION=$(PIP_TORCH_VERSION)
+endif
+
+ifneq ($(PIP_TRITON_VERSION), )
+	RUNTIME_ARGS += -o PIP_TRITON_VERSION=$(PIP_TRITON_VERSION)
+endif
+
+ifneq ($(PIP_VLLM_VERSION), )
+	RUNTIME_ARGS += -o PIP_VLLM_VERSION=$(PIP_VLLM_VERSION)
+endif
+
+ifneq ($(CUDA_VISIBLE_DEVICES), )
+	RUNTIME_ARGS += -o CUDA_VISIBLE_DEVICES=$(CUDA_VISIBLE_DEVICES)
+endif
+
+ifneq ($(ROCR_VISIBLE_DEVICES), )
+	RUNTIME_ARGS += -o ROCR_VISIBLE_DEVICES=$(ROCR_VISIBLE_DEVICES)
+endif
+
+ifneq ($(PIP_TORCH_INDEX_URL), )
+	RUNTIME_ARGS += -o PIP_TORCH_INDEX_URL=$(PIP_TORCH_INDEX_URL)
+endif
+
+ifneq ($(UV_TORCH_BACKEND), )
+	RUNTIME_ARGS += -o UV_TORCH_BACKEND=$(UV_TORCH_BACKEND)
+endif
+
+ifneq ($(PIP_VLLM_EXTRA_INDEX_URL), )
+	RUNTIME_ARGS += -o PIP_VLLM_EXTRA_INDEX_URL=$(PIP_VLLM_EXTRA_INDEX_URL)
+endif
+
+ifneq ($(PIP_VLLM_COMMIT), )
+	RUNTIME_ARGS += -o PIP_VLLM_COMMIT=$(PIP_VLLM_COMMIT)
+endif
+
+ifneq ($(create_user), )
+	RUNTIME_ARGS += -u $(create_user)
+endif
+
+define CUDA_RUNTIME_ARGS
+	$(RUNTIME_ARGS) \
+	-o CUDA_VERSION=$(CUDA_VERSION)
 endef
+
+define CPU_RUNTIME_ARGS
+	$(RUNTIME_ARGS)
+endef
+
+define ROCM_RUNTIME_ARGS
+	$(RUNTIME_ARGS) \
+	-o ROCM_VERSION=$(ROCM_VERSION)
+endef
+
 
 # Old runtime targets (DEPRECATED)
 .PHONY: triton-run
@@ -296,14 +300,77 @@ triton-run: triton-cuda-run
 triton-amd-run: triton-rocm-run
 
 
+.PHONY: base-run
+base-run: ## Run the Base container image
+	@./triton-dev-containers.sh $(RUNTIME_ARGS) -d $(BASE_IMAGE_NAME)
+
+.PHONY: cuda-run
+cuda-run: ## Run the CUDA container image
+	@./triton-dev-containers.sh $(CUDA_RUNTIME_ARGS) -d $(CUDA_IMAGE_NAME)
+
+.PHONY: cpu-run
+cpu-run: ## Run the CPU container image
+	@./triton-dev-containers.sh $(CPU_RUNTIME_ARGS) -d $(CPU_IMAGE_NAME)
+
+.PHONY: rocm-run
+rocm-run: ## Run the ROCm container image
+	@./triton-dev-containers.sh $(ROCM_RUNTIME_ARGS) -d $(ROCM_IMAGE_NAME)
+
+.PHONY: helion-cuda-run
+helion-cuda-run: ## Run the Helion CUDA container image
+	@./triton-dev-containers.sh $(CUDA_RUNTIME_ARGS) -d $(CUDA_IMAGE_NAME) -k helion
+
+.PHONY: helion-cpu-run
+helion-cpu-run: ## Run the Helion CPU container image
+	@./triton-dev-containers.sh $(CPU_RUNTIME_ARGS) -d $(CPU_IMAGE_NAME) -k helion
+
+.PHONY: helion-rocm-run
+helion-rocm-run: ## Run the Helion ROCm container image
+	@./triton-dev-containers.sh $(ROCM_RUNTIME_ARGS) -d $(ROCM_IMAGE_NAME) -k helion
+
 .PHONY: triton-cuda-run
-triton-cuda-run: ## Run the Triton devcontainer image
-	$(call run_container,$(CUDA_IMAGE_NAME),$(CUDA_IMAGE_TAG),"triton")
+triton-cuda-run: ## Run the Triton CUDA container image
+	@./triton-dev-containers.sh $(CUDA_RUNTIME_ARGS) -d $(CUDA_IMAGE_NAME) -k triton
 
 .PHONY: triton-cpu-run
-triton-cpu-run: ## Run the Triton CPU devcontainer image
-	$(call run_container,$(CPU_IMAGE_NAME),$(CPU_IMAGE_TAG),"triton-cpu")
+triton-cpu-run: ## Run the Triton CPU container image
+	@./triton-dev-containers.sh $(CPU_RUNTIME_ARGS) -d $(CPU_IMAGE_NAME) -k triton
 
 .PHONY: triton-rocm-run
-triton-rocm-run: ## Run the Triton AMD devcontainer image
-	$(call run_container,$(ROCM_IMAGE_NAME),$(ROCM_IMAGE_TAG),"triton")
+triton-rocm-run: ## Run the Triton ROCm container image
+	@./triton-dev-containers.sh $(ROCM_RUNTIME_ARGS) -d $(ROCM_IMAGE_NAME) -k triton
+
+.PHONY: torch-cuda-run
+torch-cuda-run: ## Run the PyTorch CUDA container image
+	@./triton-dev-containers.sh $(CUDA_RUNTIME_ARGS) -d $(CUDA_IMAGE_NAME) -k torch
+
+.PHONY: torch-cpu-run
+torch-cpu-run: ## Run the PyTorch CPU container image
+	@./triton-dev-containers.sh $(CPU_RUNTIME_ARGS) -d $(CPU_IMAGE_NAME) -k torch
+
+.PHONY: torch-rocm-run
+torch-rocm-run: ## Run the PyTorch ROCm container image
+	@./triton-dev-containers.sh $(ROCM_RUNTIME_ARGS) -d $(ROCM_IMAGE_NAME) -k torch
+
+.PHONY: vllm-cuda-run
+vllm-cuda-run: ## Run the vLLM CUDA container image
+	@./triton-dev-containers.sh $(CUDA_RUNTIME_ARGS) -d $(CUDA_IMAGE_NAME) -k vllm
+
+.PHONY: vllm-cpu-run
+vllm-cpu-run: ## Run the vLLM CPU container image
+	@./triton-dev-containers.sh $(CPU_RUNTIME_ARGS) -d $(CPU_IMAGE_NAME) -k vllm
+
+.PHONY: vllm-rocm-run
+vllm-rocm-run: ## Run the vLLM ROCm container image
+	@./triton-dev-containers.sh $(ROCM_RUNTIME_ARGS) -d $(ROCM_IMAGE_NAME) -k vllm
+
+##@ Runtime Script Installation
+.PHONY: install
+install: $(HOME)/.local/bin/triton-dev-containers ## Install the triton-dev-containers.sh runtime script
+
+$(HOME)/.local/bin/triton-dev-containers: triton-dev-containers.sh
+	install -m 0750 -D $< $@
+
+.PHONY: uninstall
+uninstall: ## Uninstall the triton-dev-containers.sh runtime script
+	rm -f $(HOME)/.local/bin/triton-dev-containers

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ ifneq ($(vllm_path), )
 endif
 
 ifneq ($(gitconfig_path), )
-	RUNTIME_ARGS += -o GITCONFIG=$(gitconfig_path)
+	RUNTIME_ARGS += -s GITCONFIG=$(gitconfig_path)
 endif
 
 ifeq ($(INSTALL_JUPYTER),true)

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,8 @@ help: ## Display this help.
 # System environment and tooling
 # ------------------------------------------------------------------------------
 CTR_CMD      := $(or $(shell command -v podman), $(shell command -v docker))
-STRIPPED_CMD := $(shell basename $(CTR_CMD))
-OS           := $(shell uname -s)
 mkfile_path  := $(abspath $(lastword $(MAKEFILE_LIST)))
 source_dir   := $(dir $(mkfile_path))
-SELINUXFLAG  := $(shell if [ "$(shell getenforce 2> /dev/null)" == "Enforcing" ]; then echo ":z"; fi)
 
 # ------------------------------------------------------------------------------
 # Buildtime configuration
@@ -97,8 +94,7 @@ PIP_VLLM_VERSION   ?=
 
 # Device indices (NVIDIA and AMD)
 CUDA_VISIBLE_DEVICES ?=
-HIP_DEVICES          ?= $(or $(HIP_VISIBLE_DEVICES), 0)
-ROCR_VISIBLE_DEVICES ?= $(HIP_DEVICES)
+ROCR_VISIBLE_DEVICES ?=
 
 # Source code paths
 llvm_path      ?=
@@ -122,10 +118,6 @@ PIP_VLLM_EXTRA_INDEX_URL ?=
 PIP_VLLM_COMMIT ?=
 
 create_user ?= $(USER)
-
-TRITON_CPU_BACKEND ?= 0
-
-USERNAME ?= triton
 
 USE_CCACHE ?= 0
 
@@ -218,7 +210,7 @@ ifneq ($(vllm_path), )
 endif
 
 ifneq ($(gitconfig_path), )
-	RUNTIME_ARGS += -s GITCONFIG=$(gitconfig_path)
+	RUNTIME_ARGS += -o GITCONFIG=$(gitconfig_path)
 endif
 
 ifeq ($(INSTALL_JUPYTER),true)
@@ -271,6 +263,10 @@ endif
 
 ifneq ($(PIP_VLLM_COMMIT), )
 	RUNTIME_ARGS += -o PIP_VLLM_COMMIT=$(PIP_VLLM_COMMIT)
+endif
+
+ifneq ($(USE_CCACHE), )
+	RUNTIME_ARGS += -o USE_CCACHE=$(USE_CCACHE)
 endif
 
 ifneq ($(create_user), )

--- a/scripts/devcreate_user.sh
+++ b/scripts/devcreate_user.sh
@@ -130,7 +130,7 @@ get_user_home() {
 
 setup_bashrc() {
 	if [ ! -f "${HOME}/.bashrc" ]; then
-		echo "Setting up ${HOME}/.bashrc for user $USERNAME ..."
+		echo "Setting up ${HOME}/.bashrc ..."
 		install -m 0644 -t "$HOME" \
 			/etc/skel/.bash_logout \
 			/etc/skel/.bash_profile \

--- a/triton-dev-containers.sh
+++ b/triton-dev-containers.sh
@@ -28,8 +28,8 @@ set -euo pipefail
 TARGET_DEVICE=base
 
 ## Image versions
-CENTOS_VERSION=10
-CUDA_VERSION=13-0
+CENTOS_VERSION=9
+CUDA_VERSION=12-9
 ROCM_VERSION=7.1.1
 
 DEFAULT_IMAGE_REPO=quay.io/triton-dev-containers
@@ -58,10 +58,11 @@ DELETE_ON_EXIT=false
 # Container runtime command option arrays
 declare -a CTR_ENV_OPTS
 declare -a CTR_DEVICE_OPTS
+declare -a CTR_GLOBAL_ARGS
 declare -a CTR_SECURITY_OPTS
 declare -a CTR_VOLUME_OPTS
 
-declare -A VOL_DIRS=(
+declare -A SRC_VOLS=(
 	["LLVM"]=llvm-project
 	["HELION"]=helion
 	["TRITON"]=triton
@@ -69,6 +70,8 @@ declare -A VOL_DIRS=(
 	["VLLM"]=vllm
 	["USER"]=user
 )
+
+declare -A VOL_PATHS
 
 declare -A OPTS=(
 	["INSTALL_JUPYTER"]="true | false"
@@ -171,11 +174,11 @@ setup_volumes() {
 	fi
 
 	# Custom source code path(s)
-	for vol in "${!VOL_DIRS[@]}"; do
-		vol_path=${vol}_PATH
-		if [ -n "${!vol_path:-}" ]; then
-			if [ -d "${!vol_path}" ]; then
-				CTR_VOLUME_OPTS+=("-v ${!vol_path}:/workspace/${VOL_DIRS[$vol]}${selinux_flag:-}")
+	for vol in "${!SRC_VOLS[@]}"; do
+		vol_path="${VOL_PATHS[$vol]:-}"
+		if [ -n "${vol_path:-}" ]; then
+			if [ -d "${vol_path}" ]; then
+				CTR_VOLUME_OPTS+=("-v ${vol_path}:/workspace/${SRC_VOLS[$vol]}${selinux_flag:-}")
 			else
 				echo "Specified $vol path, $vol_path, does not exist."
 				exit 1
@@ -195,7 +198,7 @@ setup_volumes() {
 }
 
 set_device_opts() {
-	case $TARGET_DEVICE in
+	case ${TARGET_DEVICE,,} in
 	rocm)
 		CTR_DEVICE_OPTS+=(
 			"--device=/dev/kfd"
@@ -258,11 +261,11 @@ set_user_args() {
 		set_env_var USER_UID "$(id -u "$USER")"
 		set_env_var USER_GID "$(id -g "$USER")"
 	elif [ "$(basename "$CTR_CMD")" = "docker" ]; then
-		CTR_ARGS=(
+		CTR_RUN_ARGS=(
 			"--user $(id -u):$(id -g)"
 		)
 	elif [ "$(basename "$CTR_CMD")" = "podman" ]; then
-		CTR_ARGS=(
+		CTR_RUN_ARGS=(
 			"--user $USER"
 		)
 	fi
@@ -290,7 +293,7 @@ while getopts "c:d:i:j:k:o:p:rs:t:u:hv" opt; do
 		TARGET_STACK=$OPTARG
 		;;
 	o)
-		SUBOPT=${OPTARG/=*/}
+		SUBOPT="${OPTARG/=*/}"
 		case "${SUBOPT^^}" in
 		CUDA_VERSION)
 			CUDA_VERSION="${OPTARG/*=/}"
@@ -356,7 +359,7 @@ while getopts "c:d:i:j:k:o:p:rs:t:u:hv" opt; do
 			set_env_var UV_TORCH_BACKEND "${OPTARG/*=/}"
 			;;
 		*)
-			echo "Unknown option ${OPTARG}."
+			echo "Unknown option, ${OPTARG}."
 			exit 1
 			;;
 		esac
@@ -364,51 +367,34 @@ while getopts "c:d:i:j:k:o:p:rs:t:u:hv" opt; do
 	p)
 		INSTALL_JUPYTER=true
 		if [ "${OPTARG^^}" = "AUTO" ]; then
-			JUPYTER_NOTEBOOK_PORT=$DEFAULT_PORT
+			JUPYTER_NOTEBOOK_PORT="$DEFAULT_PORT"
 		else
-			JUPYTER_NOTEBOOK_PORT=$OPTARG
+			JUPYTER_NOTEBOOK_PORT="$OPTARG"
 		fi
 		;;
 	r)
 		DELETE_ON_EXIT=true
 		;;
 	s)
-		SUBOPT=${OPTARG/=*/}
-		case "${SUBOPT^^}" in
-		LLVM)
-			LLVM_PATH="${OPTARG/*=/}"
-			set_env_var "INSTALL_LLVM" source
-			;;
-		HELION)
-			HELION_PATH="${OPTARG/*=/}"
-			set_env_var "INSTALL_HELION" source
-			;;
-		TORCH)
-			TORCH_PATH="${OPTARG/*=/}"
-			set_env_var "INSTALL_TORCH" source
-			;;
-		TRITON)
-			TRITON_PATH="${OPTARG/*=/}"
-			set_env_var "INSTALL_TRITON" source
-			;;
-		VLLM)
-			VLLM_PATH="${OPTARG/*=/}"
-			set_env_var "INSTALL_VLLM" source
-			;;
-		USER)
-			USER_PATH="${OPTARG/*=/}"
+		SUBOPT="${OPTARG/=*/}"
+		case ${SUBOPT,,} in
+		llvm | helion | torch | triton | vllm | user)
+			VOL_PATHS["${SUBOPT^^}"]="${OPTARG/*=/}"
+			if [ "${SUBOPT^^}" != "USER" ]; then
+				set_env_var "INSTALL_${SUBOPT^^}" source
+			fi
 			;;
 		*)
-			echo "Unknown source path $OPTARG"
+			echo "Unknown source path, $OPTARG"
 			exit 1
 			;;
 		esac
 		;;
 	t)
-		IMAGE_TAG=$OPTARG
+		IMAGE_TAG="$OPTARG"
 		;;
 	u)
-		USERNAME=$OPTARG
+		USERNAME="$OPTARG"
 		;;
 	h)
 		usage
@@ -418,7 +404,7 @@ while getopts "c:d:i:j:k:o:p:rs:t:u:hv" opt; do
 		set -x
 		;;
 	*)
-		echo "Unknown option $opt."
+		echo "Unknown option, $opt."
 		exit 1
 		;;
 	esac
@@ -458,7 +444,7 @@ set_user_args
 
 # Set stack options
 if [ -n "${TARGET_STACK:-}" ]; then
-	case $TARGET_STACK in
+	case ${TARGET_STACK,,} in
 	helion)
 		set_env_var INSTALL_HELION "source"
 		set_env_var INSTALL_TORCH "release"
@@ -480,7 +466,7 @@ if [ -n "${TARGET_STACK:-}" ]; then
 	esac
 fi
 
-CTR_ARGS+=(
+CTR_RUN_ARGS+=(
 	"${CTR_ENV_OPTS[@]:-}"
 	"${CTR_DEVICE_OPTS[@]:-}"
 	"${CTR_PORT_OPT:-}"
@@ -489,16 +475,16 @@ CTR_ARGS+=(
 )
 
 if [ -n "${REMOTE_CONNECTION:-}" ]; then
-	CTR_CONNECTION="-r -c $REMOTE_CONNECTION"
+	CTR_GLOBAL_ARGS+=("-r" "-c $REMOTE_CONNECTION")
 fi
 
 if [ "${DELETE_ON_EXIT:-}" = "true" ]; then
-	CTR_ARGS+=("--rm")
+	CTR_RUN_ARGS+=("--rm")
 fi
 
 IMAGE=${IMAGE:-${DEFAULT_IMAGE_REPO}/${TARGET_DEVICE}:${IMAGE_TAG:-${DEFAULT_IMAGE_TAG}}}
 
 printf "Running container image: %s with %s\n" "$IMAGE" "$CTR_CMD"
-printf "%s %s run -ti %s %s bash\n" "$CTR_CMD" "${CTR_CONNECTION:-}" \
-	"${CTR_ARGS[*]}" "$IMAGE"
-$CTR_CMD ${CTR_CONNECTION:-} run -ti ${CTR_ARGS[@]} "${IMAGE}" bash
+printf "%s %s run -ti %s %s bash\n" "$CTR_CMD" "${CTR_GLOBAL_ARGS[*]}" \
+	"${CTR_RUN_ARGS[*]}" "$IMAGE"
+$CTR_CMD "${CTR_GLOBAL_ARGS[@]}" run -ti ${CTR_RUN_ARGS[@]} "${IMAGE}" bash

--- a/triton-dev-containers.sh
+++ b/triton-dev-containers.sh
@@ -28,52 +28,78 @@ set -euo pipefail
 TARGET_DEVICE=base
 
 ## Image versions
-CENTOS_VERSION=9
-CUDA_VERSION=12-9
-ROCM_VERSION=7.1.1
-
+DEFAULT_CENTOS_VERSION=9
 DEFAULT_IMAGE_REPO=quay.io/triton-dev-containers
-DEFAULT_IMAGE_TAG=centos${CENTOS_VERSION}
+DEFAULT_IMAGE_TAG=centos${DEFAULT_CENTOS_VERSION}
 DEFAULT_IMAGE=${DEFAULT_IMAGE_REPO}/${TARGET_DEVICE}
 
-GITCONFIG_PATH="${HOME}/.gitconfig"
-CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
-ROCR_VISIBLE_DEVICES=${ROCR_VISIBLE_DEVICES:-0}
-
 # PyPi Index URLs
-PIP_TORCH_INDEX_URL=https://download.pytorch.org/whl
 VLLM_INDEX_URL_BASE=https://wheels.vllm.ai
 
 ## Jupyter notebook
-INSTALL_JUPYTER=false
 DEFAULT_PORT=8888
-
-## Image modifiers
-MAX_JOBS=${MAX_JOBS:-$(nproc --all)}
-USE_CCACHE=0
 
 ## Adds --rm to the runtime args
 DELETE_ON_EXIT=false
 
-# Container runtime command option arrays
-declare -a CTR_ENV_OPTS
-declare -a CTR_DEVICE_OPTS
+# Container runtime global and command arguments
 declare -a CTR_GLOBAL_ARGS
+declare -a CTR_RUN_ARGS
+
+# Container runtime command option arrays
+declare -a CTR_DEVICE_OPTS
+declare -a CTR_ENV_OPTS
+declare -a CTR_PORT_OPTS
 declare -a CTR_SECURITY_OPTS
+declare -a CTR_USER_OPTS
 declare -a CTR_VOLUME_OPTS
 
 declare -A SRC_VOLS=(
-	["LLVM"]=llvm-project
-	["HELION"]=helion
-	["TRITON"]=triton
-	["TORCH"]=torch
-	["VLLM"]=vllm
-	["USER"]=user
+	["GITCONFIG"]=/etc/gitconfig
+	["HELION"]=/workspace/helion
+	["LLVM"]=/workspace/llvm-project
+	["TORCH"]=/workspace/torch
+	["TRITON"]=/workspace/triton
+	["USER"]=/workspace/user
+	["VLLM"]=/workspace/vllm
 )
 
-declare -A VOL_PATHS
+declare -A VOL_PATHS=(
+	["GITCONFIG"]="${HOME}/.gitconfig"
+)
 
-declare -A OPTS=(
+declare -A DEFAULT_ENV_OPTS=(
+	["CENTOS_VERSION"]=9
+	["CUDA_VERSION"]=12-9
+	["CUDA_VISIBLE_DEVICES"]=${CUDA_VISIBLE_DEVICES:-0}
+	["DISPLAY"]=${DISPLAY:-}
+	["INSTALL_JUPYTER"]="false"
+	["INSTALL_TOOLS"]="false"
+	["INSTALL_LLVM"]="skip"
+	["INSTALL_HELION"]="skip"
+	["INSTALL_TORCH"]="skip"
+	["INSTALL_TRITON"]="skip"
+	["INSTALL_VLLM"]="skip"
+	["MAX_JOBS"]=${MAX_JOBS:-$(nproc --all)}
+	["PIP_HELION_VERSION"]=""
+	["PIP_TORCH_INDEX_URL"]="https://download.pytorch.org/whl"
+	["PIP_TORCH_VERSION"]=""
+	["PIP_TRITON_VERSION"]=""
+	["PIP_VLLM_COMMIT"]=""
+	["PIP_VLLM_EXTRA_INDEX_URL"]=""
+	["PIP_VLLM_VERSION"]=""
+	["ROCM_VERSION"]=7.1.1
+	["ROCR_VISIBLE_DEVICES"]=${ROCR_VISIBLE_DEVICES:-0}
+	["USE_CCACHE"]=0
+	["USER"]=""
+	["USER_UID"]=""
+	["USER_GID"]=""
+	["UV_TORCH_BACKEND"]=""
+	["WAYLAND_DISPLAY"]=${WAYLAND_DISPLAY:-}
+	["XDG_RUNTIME_DIR"]="/tmp"
+)
+
+declare -A ENV_INSTALL_OPTS=(
 	["INSTALL_JUPYTER"]="true | false"
 	["INSTALL_TOOLS"]="true | false"
 	["INSTALL_LLVM"]="source | skip"
@@ -82,6 +108,8 @@ declare -A OPTS=(
 	["INSTALL_TRITON"]="release | source | skip"
 	["INSTALL_VLLM"]="nightly | release | source | skip"
 )
+
+declare -A ENV_OPTS
 
 usage() {
 	cat >&2 <<EOF
@@ -93,39 +121,40 @@ Options
     -j MAX_JOBS                  Maximum number of jobs to use when building Triton/Helion/PyTorch/vLLM (Default: $MAX_JOBS)
     -k TARGET_STACK              Target stack [ helion | torch | triton | vllm ]
     -o OPTION=ARGUMENT           Specify a argument for an option
-        CUDA_VERSION                 CUDA version (Default: $CUDA_VERSION)
+        CUDA_VERSION                 CUDA version (Default: ${DEFAULT_ENV_OPTS["CUDA_VERSION"]})
         CUDA_VISIBLE_DEVICES         List of NVIDIA device indices or UUIDs (i.e. 0,GPU-DEADBEEFDEADBEEF)
-        GITCONFIG                    /path/to/.gitconfig (Default: $GITCONFIG_PATH)
-        INSTALL_JUPYTER              Install the Jupyter notebook server
-                                         [ ${OPTS["INSTALL_JUPYTER"]} ]
-        INSTALL_TOOLS                Install debugging and profiling tools (i.e. NSIGHT or ROCm Systems)
-                                         [ ${OPTS["INSTALL_TOOLS"]} ]
-        INSTALL_LLVM                 Setup the container to build LLVM from source
-                                         [ ${OPTS["INSTALL_LLVM"]} ]
-        INSTALL_HELION               Install or setup the container for building Helion
-                                         [ ${OPTS["INSTALL_HELION"]} ]
-        INSTALL_TORCH                Install or setup the container for building PyTorch
-                                         [ ${OPTS["INSTALL_TORCH"]} ]
-        INSTALL_TRITON               Install or setup the container for building Triton
-                                         [ ${OPTS["INSTALL_TRITON"]} ]
-        INSTALL_VLLM                 Install or setup the container for building vLLM
-                                         [ ${OPTS["INSTALL_VLLM"]} ]
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_JUPYTER"]} ]
+        INSTALL_JUPYTER              Install the Jupyter notebook server (Default: ${DEFAULT_ENV_OPTS["INSTALL_JUPYTER"]})
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_JUPYTER"]} ]
+        INSTALL_TOOLS                Install debugging and profiling tools (i.e. NSIGHT or ROCm Systems) (Default: ${DEFAULT_ENV_OPTS["INSTALL_TOOLS"]})
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_TOOLS"]} ]
+        INSTALL_LLVM                 Setup the container to build LLVM from source (Default: ${DEFAULT_ENV_OPTS["INSTALL_LLVM"]})
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_LLVM"]} ]
+        INSTALL_HELION               Install or setup the container for building Helion (Default: ${DEFAULT_ENV_OPTS["INSTALL_HELION"]})
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_HELION"]} ]
+        INSTALL_TORCH                Install or setup the container for building PyTorch (Default: ${DEFAULT_ENV_OPTS["INSTALL_TORCH"]})
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_TORCH"]} ]
+        INSTALL_TRITON               Install or setup the container for building Triton (Default: ${DEFAULT_ENV_OPTS["INSTALL_TRITON"]})
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_TRITON"]} ]
+        INSTALL_VLLM                 Install or setup the container for building vLLM (Default: ${DEFAULT_ENV_OPTS["INSTALL_VLLM"]})
+                                         [ ${ENV_INSTALL_OPTS["INSTALL_VLLM"]} ]
         PIP_HELION_VERSION           Helion wheel version
-        PIP_TORCH_INDEX_URL          http://<url> (Default: $PIP_TORCH_INDEX_URL)
+        PIP_TORCH_INDEX_URL          http://<url> (Default: ${DEFAULT_ENV_OPTS["PIP_TORCH_INDEX_URL"]})
         PIP_TORCH_VERSION            Torch wheel version
         PIP_TRITON_VERSION           Triton wheel version
         PIP_VLLM_COMMIT              vLLM git commit hash for wheel install ($VLLM_INDEX_URL_BASE/<commit>)
         PIP_VLLM_EXTRA_INDEX_URL     http://<url> [Not used with PIP_VLLM_COMMIT] (Default: $VLLM_INDEX_URL_BASE)
         PIP_VLLM_VERSION             vLLM wheel version
-        ROCM_VERSION                 ROCm version (Default: $ROCM_VERSION)
+        ROCM_VERSION                 ROCm version (Default: ${DEFAULT_ENV_OPTS["ROCM_VERSION"]})
         ROCR_VISIBLE_DEVICES         List of AMD device indices or UUIDs (i.e. 0,GPU-DEADBEEFDEADBEEF)
-        USE_CCACHE                   Enable ccache [ 0 | 1 ] (Default: $USE_CCACHE)
-        UV_TORCH_BACKEND             Framwork version: [ cu${CUDA_VERSION//-/} | rocm${ROCM_VERSION%.*} | cpu ]
+        USE_CCACHE                   Enable ccache [ 0 | 1 ] (Default: ${DEFAULT_ENV_OPTS["USE_CCACHE"]})
+        UV_TORCH_BACKEND             Framwork version: [ cu${DEFAULT_ENV_OPTS["CUDA_VERSION"]//-/} | rocm${DEFAULT_ENV_OPTS["ROCM_VERSION"]%.*} | cpu ]
     -p [ DEFAULT | PORT ]        Expose the specified port for the Jupyter notebook server (Default: $DEFAULT_PORT)
     -r                           Remove the container on exit
     -s SOURCE=PATH               Local source directories to mount as volumes
-        LLVM                         /path/to/llvm/source
+        GITCONFIG                    /path/to/gitconfig (Default: ${VOL_PATHS["GITCONFIG"]})
         HELION                       /path/to/helion/source
+        LLVM                         /path/to/llvm/source
         TORCH                        /path/to/torch/source
         TRITON                       /path/to/triton/source
         USER                         /path/to/user/source
@@ -137,19 +166,25 @@ Options
 EOF
 }
 
-set_env_var() {
+set_env_opt() {
 	local key=$1
 	local value=$2
 
-	if [[ ! "${CTR_ENV_OPTS[*]}" =~ $key ]]; then
-		if [[ "${!OPTS[*]}" =~ $key ]]; then
-			if [[ ! "${OPTS[$key]}" =~ $value ]]; then
-				echo "Bad option, $value, for $key, can only be ${OPTS[$key]}"
-				exit 1
+	if [[ ! "${!ENV_OPTS[*]}" =~ $key ]]; then
+		if [[ "${!DEFAULT_ENV_OPTS[*]}" =~ $key ]]; then
+			if [[ "${!ENV_INSTALL_OPTS[*]}" =~ $key ]]; then
+				if [[ ! "${ENV_INSTALL_OPTS[$key]}" =~ $value ]]; then
+					echo "Bad install option, $value, for $key, can only be ${ENV_INSTALL_OPTS[$key]}"
+					exit 1
+				fi
 			fi
-		fi
 
-		CTR_ENV_OPTS+=("-e $key=$value")
+			ENV_OPTS[$key]="$value"
+			CTR_ENV_OPTS+=("-e $key=$value")
+		else
+			echo "Unknown env option, $key."
+			exit 1
+		fi
 	fi
 }
 
@@ -177,9 +212,12 @@ setup_volumes() {
 	for vol in "${!SRC_VOLS[@]}"; do
 		vol_path="${VOL_PATHS[$vol]:-}"
 		if [ -n "${vol_path:-}" ]; then
-			if [ -d "${vol_path}" ]; then
-				CTR_VOLUME_OPTS+=("-v ${vol_path}:/workspace/${SRC_VOLS[$vol]}${selinux_flag:-}")
-			else
+			if [ -e "${vol_path}" ]; then
+				CTR_VOLUME_OPTS+=("-v ${vol_path}:${SRC_VOLS[$vol]}${selinux_flag:-}")
+				if [ "$vol" != "USER" ] && [ "$vol" != "GITCONFIG" ]; then
+					set_env_opt "INSTALL_${vol^^}" source
+				fi
+			elif [ "$vol" != "GITCONFIG" ]; then
 				echo "Specified $vol path, $vol_path, does not exist."
 				exit 1
 			fi
@@ -188,12 +226,10 @@ setup_volumes() {
 
 	# User management for non-Mac OS's
 	if [ "$(uname -s)" != "Darwin" ] && ! getent passwd "$USER" >/dev/null && [ -n "${USERNAME:-}" ]; then
-		CTR_VOLUME_OPTS+=("-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro")
-	fi
-
-	# Gitconfig
-	if [ -f "${GITCONFIG_PATH:-}" ]; then
-		CTR_VOLUME_OPTS+=("-v ${GITCONFIG_PATH}:/etc/gitconfig${selinux_flag:-}")
+		CTR_VOLUME_OPTS+=(
+			"-v /etc/passwd:/etc/passwd:ro"
+			"-v /etc/group:/etc/group:ro"
+		)
 	fi
 }
 
@@ -212,9 +248,9 @@ set_device_opts() {
 			"--security-opt seccomp=unconfined"
 		)
 
-		set_env_var ROCM_VERSION "$ROCM_VERSION"
-		set_env_var ROCR_VISIBLE_DEVICES "$ROCR_VISIBLE_DEVICES"
-		IMAGE_TAG=${ROCM_VERSION}-${DEFAULT_IMAGE_TAG}
+		set_env_opt ROCM_VERSION "${DEFAULT_ENV_OPTS["ROCM_VERSION"]}"
+		set_env_opt ROCR_VISIBLE_DEVICES "${DEFAULT_ENV_OPTS["ROCR_VISIBLE_DEVICES"]}"
+		IMAGE_TAG="${ENV_OPTS["ROCM_VERSION"]}"-${DEFAULT_IMAGE_TAG}
 		;;
 	cuda)
 		if command -v nvidia-ctk >/dev/null 2>&1 && nvidia-ctk cdi list | grep -q "nvidia.com/gpu=all"; then
@@ -231,10 +267,10 @@ set_device_opts() {
 				"--cap-add=SYS_ADMIN"
 			)
 
-			if [ -n "${DISPLAY:-}" ] && [ -n "${WAYLAND_DISPLAY:-}" ]; then
-				set_env_var DISPLAY "$DISPLAY"
-				set_env_var WAYLAND_DISPLAY "$WAYLAND_DISPLAY"
-				set_env_var XDG_RUNTIME_DIR /tmp
+			if [ -n "${DEFAULT_ENV_OPTS["DISPLAY"]:-}" ] && [ -n "${DEFAULT_ENV_OPTS["WAYLAND_DISPLAY"]:-}" ]; then
+				set_env_opt DISPLAY "${DEFAULT_ENV_OPTS["DISPLAY"]}"
+				set_env_opt WAYLAND_DISPLAY "${DEFAULT_ENV_OPTS["WAYLAND_DISPLAY"]}"
+				set_env_opt XDG_RUNTIME_DIR "${DEFAULT_ENV_OPTS["XDG_RUNTIME_DIR"]}"
 
 				CTR_VOLUME_OPTS+=(
 					"-v ${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:/tmp/${WAYLAND_DISPLAY}:ro"
@@ -244,9 +280,9 @@ set_device_opts() {
 			fi
 		fi
 
-		set_env_var CUDA_VERSION "$CUDA_VERSION"
-		set_env_var CUDA_VISIBLE_DEVICES "$CUDA_VISIBLE_DEVICES"
-		IMAGE_TAG=${CUDA_VERSION}-${DEFAULT_IMAGE_TAG}
+		set_env_opt CUDA_VERSION "${DEFAULT_ENV_OPTS["CUDA_VERSION"]}"
+		set_env_opt CUDA_VISIBLE_DEVICES "${DEFAULT_ENV_OPTS["CUDA_VISIBLE_DEVICES"]}"
+		IMAGE_TAG=${ENV_OPTS["CUDA_VERSION"]}-${DEFAULT_IMAGE_TAG}
 		;;
 	esac
 }
@@ -257,15 +293,15 @@ set_user_args() {
 	fi
 
 	if [ -n "${USERNAME:-}" ] && [ "${USERNAME:-}" != "root" ]; then
-		set_env_var USER "$USERNAME"
-		set_env_var USER_UID "$(id -u "$USER")"
-		set_env_var USER_GID "$(id -g "$USER")"
+		set_env_opt USER "$USERNAME"
+		set_env_opt USER_UID "$(id -u "$USER")"
+		set_env_opt USER_GID "$(id -g "$USER")"
 	elif [ "$(basename "$CTR_CMD")" = "docker" ]; then
-		CTR_RUN_ARGS=(
+		CTR_USER_OPTS+=(
 			"--user $(id -u):$(id -g)"
 		)
 	elif [ "$(basename "$CTR_CMD")" = "podman" ]; then
-		CTR_RUN_ARGS=(
+		CTR_USER_OPTS+=(
 			"--user $USER"
 		)
 	fi
@@ -287,85 +323,17 @@ while getopts "c:d:i:j:k:o:p:rs:t:u:hv" opt; do
 		IMAGE="$OPTARG"
 		;;
 	j)
-		MAX_JOBS=$OPTARG
+		set_env_opt MAX_JOBS "$OPTARG"
 		;;
 	k)
 		TARGET_STACK=$OPTARG
 		;;
 	o)
 		SUBOPT="${OPTARG/=*/}"
-		case "${SUBOPT^^}" in
-		CUDA_VERSION)
-			CUDA_VERSION="${OPTARG/*=/}"
-			;;
-		CUDA_VISIBLE_DEVICES)
-			CUDA_VISIBLE_DEVICES="${OPTARG/*=/}"
-			;;
-		GITCONFIG)
-			GITCONFIG_PATH="${OPTARG/*=/}"
-			;;
-		INSTALL_JUPYTER)
-			INSTALL_JUPYTER="${OPTARG/*=/}"
-			;;
-		INSTALL_TOOLS)
-			set_env_var INSTALL_TOOLS "${OPTARG/*=/}"
-			;;
-		INSTALL_LLVM)
-			set_env_var INSTALL_LLVM "${OPTARG/*=/}"
-			;;
-		INSTALL_HELION)
-			set_env_var INSTALL_HELION "${OPTARG/*=/}"
-			;;
-		INSTALL_TORCH)
-			set_env_var INSTALL_TORCH "${OPTARG/*=/}"
-			;;
-		INSTALL_TRITON)
-			set_env_var INSTALL_TRITON "${OPTARG/*=/}"
-			;;
-		INSTALL_VLLM)
-			set_env_var INSTALL_VLLM "${OPTARG/*=/}"
-			;;
-		PIP_HELION_VERSION)
-			set_env_var PIP_HELION_VERSION "${OPTARG/*=/}"
-			;;
-		PIP_TORCH_INDEX_URL)
-			set_env_var PIP_TORCH_INDEX_URL "${OPTARG/*=/}"
-			;;
-		PIP_TORCH_VERSION)
-			set_env_var PIP_TORCH_VERSION "${OPTARG/*=/}"
-			;;
-		PIP_TRITON_VERSION)
-			set_env_var PIP_TRITON_VERSION "${OPTARG/*=/}"
-			;;
-		PIP_VLLM_COMMIT)
-			set_env_var PIP_VLLM_COMMIT "${OPTARG/*=/}"
-			;;
-		PIP_VLLM_EXTRA_INDEX_URL)
-			set_env_var PIP_VLLM_EXTRA_INDEX_URL "${OPTARG/*=/}"
-			;;
-		PIP_VLLM_VERSION)
-			set_env_var PIP_VLLM_VERSION "${OPTARG/*=/}"
-			;;
-		ROCM_VERSION)
-			ROCM_VERSION="${OPTARG/*=/}"
-			;;
-		ROCR_VISIBLE_DEVICES)
-			ROCR_VISIBLE_DEVICES="${OPTARG/*=/}"
-			;;
-		USE_CCACHE)
-			set_env_var USE_CCACHE "${OPTARG/*=/}"
-			;;
-		UV_TORCH_BACKEND)
-			set_env_var UV_TORCH_BACKEND "${OPTARG/*=/}"
-			;;
-		*)
-			echo "Unknown option, ${OPTARG}."
-			exit 1
-			;;
-		esac
+		set_env_opt "${SUBOPT^^}" "${OPTARG/*=/}"
 		;;
 	p)
-		INSTALL_JUPYTER=true
+		set_env_opt INSTALL_JUPYTER true
 		if [ "${OPTARG^^}" = "AUTO" ]; then
 			JUPYTER_NOTEBOOK_PORT="$DEFAULT_PORT"
 		else
@@ -377,18 +345,12 @@ while getopts "c:d:i:j:k:o:p:rs:t:u:hv" opt; do
 		;;
 	s)
 		SUBOPT="${OPTARG/=*/}"
-		case ${SUBOPT,,} in
-		llvm | helion | torch | triton | vllm | user)
+		if [[ "${!SRC_VOLS[*]}" =~ ${SUBOPT^^} ]]; then
 			VOL_PATHS["${SUBOPT^^}"]="${OPTARG/*=/}"
-			if [ "${SUBOPT^^}" != "USER" ]; then
-				set_env_var "INSTALL_${SUBOPT^^}" source
-			fi
-			;;
-		*)
+		else
 			echo "Unknown source path, $OPTARG"
 			exit 1
-			;;
-		esac
+		fi
 		;;
 	t)
 		IMAGE_TAG="$OPTARG"
@@ -431,13 +393,10 @@ fi
 
 # Jupyter Notebook
 if [ "${INSTALL_JUPYTER:-}" = "true" ]; then
-	CTR_PORT_OPT="-p ${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}:${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}"
-	set_env_var INSTALL_JUPYTER "$INSTALL_JUPYTER"
-	set_env_var NOTEBOOK_PORT "${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}"
+	CTR_PORT_OPTS+=("-p ${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}:${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}")
+	set_env_opt INSTALL_JUPYTER "$INSTALL_JUPYTER"
+	set_env_opt NOTEBOOK_PORT "${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}"
 fi
-
-# Environment Arguments
-set_env_var MAX_JOBS "$MAX_JOBS"
 
 # User args
 set_user_args
@@ -446,18 +405,18 @@ set_user_args
 if [ -n "${TARGET_STACK:-}" ]; then
 	case ${TARGET_STACK,,} in
 	helion)
-		set_env_var INSTALL_HELION "source"
-		set_env_var INSTALL_TORCH "release"
+		set_env_opt INSTALL_HELION "source"
+		set_env_opt INSTALL_TORCH "release"
 		;;
 	torch)
-		set_env_var INSTALL_TORCH "source"
+		set_env_opt INSTALL_TORCH "source"
 		;;
 	triton)
-		set_env_var INSTALL_TORCH "release"
-		set_env_var INSTALL_TRITON "source"
+		set_env_opt INSTALL_TORCH "release"
+		set_env_opt INSTALL_TRITON "source"
 		;;
 	vllm)
-		set_env_var INSTALL_VLLM "source"
+		set_env_opt INSTALL_VLLM "source"
 		;;
 	*)
 		echo "Unknown stack, $TARGET_STACK"
@@ -465,14 +424,6 @@ if [ -n "${TARGET_STACK:-}" ]; then
 		;;
 	esac
 fi
-
-CTR_RUN_ARGS+=(
-	"${CTR_ENV_OPTS[@]:-}"
-	"${CTR_DEVICE_OPTS[@]:-}"
-	"${CTR_PORT_OPT:-}"
-	"${CTR_SECURITY_OPTS[@]:-}"
-	"${CTR_VOLUME_OPTS[@]:-}"
-)
 
 if [ -n "${REMOTE_CONNECTION:-}" ]; then
 	CTR_GLOBAL_ARGS+=("-r" "-c $REMOTE_CONNECTION")
@@ -484,7 +435,21 @@ fi
 
 IMAGE=${IMAGE:-${DEFAULT_IMAGE_REPO}/${TARGET_DEVICE}:${IMAGE_TAG:-${DEFAULT_IMAGE_TAG}}}
 
-printf "Running container image: %s with %s\n" "$IMAGE" "$CTR_CMD"
-printf "%s %s run -ti %s %s bash\n" "$CTR_CMD" "${CTR_GLOBAL_ARGS[*]}" \
-	"${CTR_RUN_ARGS[*]}" "$IMAGE"
-$CTR_CMD "${CTR_GLOBAL_ARGS[@]}" run -ti ${CTR_RUN_ARGS[@]} "${IMAGE}" bash
+# Build and cleanup the run command
+RUN_CMD="$CTR_CMD \
+	${CTR_GLOBAL_ARGS[*]:-} \
+	run \
+	-ti \
+	${CTR_RUN_ARGS[*]:-} \
+	${CTR_ENV_OPTS[*]:-} \
+	${CTR_DEVICE_OPTS[*]:-} \
+	${CTR_PORT_OPTS:-} \
+	${CTR_SECURITY_OPTS[*]:-} \
+	${CTR_VOLUME_OPTS[*]:-} \
+	${IMAGE} \
+	bash"
+RUN_CMD=$(echo "$RUN_CMD" | tr -d '\t\n' | tr -s '\s')
+
+echo "Running container image: $IMAGE with $CTR_CMD"
+echo "$RUN_CMD"
+$RUN_CMD

--- a/triton-dev-containers.sh
+++ b/triton-dev-containers.sh
@@ -1,0 +1,504 @@
+#! /bin/bash -e
+
+trap "echo -e '\nScript interrupted. Exiting gracefully.'; exit 1" SIGINT
+
+# Copyright (C) 2024-2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+# If you are on an OS that has the user in /etc/passwd then we can pass
+# the user from the host to the pod. Otherwise we default to create the
+# user inside the container.
+# With podman if you aren't creating the user you need to explicitly pass
+# the user as --user $(USER) to start the container as that user.
+
+# Global Default Variables
+TARGET_DEVICE=base
+
+## Image versions
+CENTOS_VERSION=10
+CUDA_VERSION=13-0
+ROCM_VERSION=7.1.1
+
+DEFAULT_IMAGE_REPO=quay.io/triton-dev-containers
+DEFAULT_IMAGE_TAG=centos${CENTOS_VERSION}
+DEFAULT_IMAGE=${DEFAULT_IMAGE_REPO}/${TARGET_DEVICE}
+
+GITCONFIG_PATH="${HOME}/.gitconfig"
+CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+ROCR_VISIBLE_DEVICES=${ROCR_VISIBLE_DEVICES:-0}
+
+# PyPi Index URLs
+PIP_TORCH_INDEX_URL=https://download.pytorch.org/whl
+VLLM_INDEX_URL_BASE=https://wheels.vllm.ai
+
+## Jupyter notebook
+INSTALL_JUPYTER=false
+DEFAULT_PORT=8888
+
+## Image modifiers
+MAX_JOBS=${MAX_JOBS:-$(nproc --all)}
+USE_CCACHE=0
+
+## Adds --rm to the runtime args
+DELETE_ON_EXIT=false
+
+# Container runtime command option arrays
+declare -a CTR_ENV_OPTS
+declare -a CTR_DEVICE_OPTS
+declare -a CTR_SECURITY_OPTS
+declare -a CTR_VOLUME_OPTS
+
+declare -A VOL_DIRS=(
+	["LLVM"]=llvm-project
+	["HELION"]=helion
+	["TRITON"]=triton
+	["TORCH"]=torch
+	["VLLM"]=vllm
+	["USER"]=user
+)
+
+declare -A OPTS=(
+	["INSTALL_JUPYTER"]="true | false"
+	["INSTALL_TOOLS"]="true | false"
+	["INSTALL_LLVM"]="source | skip"
+	["INSTALL_HELION"]="nightly | release | source | test | skip"
+	["INSTALL_TORCH"]="nightly | release | source | test | skip"
+	["INSTALL_TRITON"]="release | source | skip"
+	["INSTALL_VLLM"]="nightly | release | source | skip"
+)
+
+usage() {
+	cat >&2 <<EOF
+Usage: ${0##*/} [OPTION]...
+Options
+    -c REMOTE_CONNECTION         Use the remote podman system
+    -d DEVICE                    Target device [ base | cpu | cuda | rocm ] (Default: $TARGET_DEVICE)
+    -i IMAGE                     Image (Default: $DEFAULT_IMAGE)
+    -j MAX_JOBS                  Maximum number of jobs to use when building Triton/Helion/PyTorch/vLLM (Default: $MAX_JOBS)
+    -k TARGET_STACK              Target stack [ helion | torch | triton | vllm ]
+    -o OPTION=ARGUMENT           Specify a argument for an option
+        CUDA_VERSION                 CUDA version (Default: $CUDA_VERSION)
+        CUDA_VISIBLE_DEVICES         List of NVIDIA device indices or UUIDs (i.e. 0,GPU-DEADBEEFDEADBEEF)
+        GITCONFIG                    /path/to/.gitconfig (Default: $GITCONFIG_PATH)
+        INSTALL_JUPYTER              Install the Jupyter notebook server
+                                         [ ${OPTS["INSTALL_JUPYTER"]} ]
+        INSTALL_TOOLS                Install debugging and profiling tools (i.e. NSIGHT or ROCm Systems)
+                                         [ ${OPTS["INSTALL_TOOLS"]} ]
+        INSTALL_LLVM                 Setup the container to build LLVM from source
+                                         [ ${OPTS["INSTALL_LLVM"]} ]
+        INSTALL_HELION               Install or setup the container for building Helion
+                                         [ ${OPTS["INSTALL_HELION"]} ]
+        INSTALL_TORCH                Install or setup the container for building PyTorch
+                                         [ ${OPTS["INSTALL_TORCH"]} ]
+        INSTALL_TRITON               Install or setup the container for building Triton
+                                         [ ${OPTS["INSTALL_TRITON"]} ]
+        INSTALL_VLLM                 Install or setup the container for building vLLM
+                                         [ ${OPTS["INSTALL_VLLM"]} ]
+        PIP_HELION_VERSION           Helion wheel version
+        PIP_TORCH_INDEX_URL          http://<url> (Default: $PIP_TORCH_INDEX_URL)
+        PIP_TORCH_VERSION            Torch wheel version
+        PIP_TRITON_VERSION           Triton wheel version
+        PIP_VLLM_COMMIT              vLLM git commit hash for wheel install ($VLLM_INDEX_URL_BASE/<commit>)
+        PIP_VLLM_EXTRA_INDEX_URL     http://<url> [Not used with PIP_VLLM_COMMIT] (Default: $VLLM_INDEX_URL_BASE)
+        PIP_VLLM_VERSION             vLLM wheel version
+        ROCM_VERSION                 ROCm version (Default: $ROCM_VERSION)
+        ROCR_VISIBLE_DEVICES         List of AMD device indices or UUIDs (i.e. 0,GPU-DEADBEEFDEADBEEF)
+        USE_CCACHE                   Enable ccache [ 0 | 1 ] (Default: $USE_CCACHE)
+        UV_TORCH_BACKEND             Framwork version: [ cu${CUDA_VERSION//-/} | rocm${ROCM_VERSION%.*} | cpu ]
+    -p [ DEFAULT | PORT ]        Expose the specified port for the Jupyter notebook server (Default: $DEFAULT_PORT)
+    -r                           Remove the container on exit
+    -s SOURCE=PATH               Local source directories to mount as volumes
+        LLVM                         /path/to/llvm/source
+        HELION                       /path/to/helion/source
+        TORCH                        /path/to/torch/source
+        TRITON                       /path/to/triton/source
+        USER                         /path/to/user/source
+        VLLM                         /path/to/vllm/source
+    -t IMAGE_TAG                 Image tag (Default: $DEFAULT_IMAGE_TAG)
+    -u USERNAME                  Username to use inside the image
+    -h                           Print usage
+    -v                           Verbose
+EOF
+}
+
+set_env_var() {
+	local key=$1
+	local value=$2
+
+	if [[ ! "${CTR_ENV_OPTS[*]}" =~ $key ]]; then
+		if [[ "${!OPTS[*]}" =~ $key ]]; then
+			if [[ ! "${OPTS[$key]}" =~ $value ]]; then
+				echo "Bad option, $value, for $key, can only be ${OPTS[$key]}"
+				exit 1
+			fi
+		fi
+
+		CTR_ENV_OPTS+=("-e $key=$value")
+	fi
+}
+
+set_container_runtime() {
+	if command -v podman &>/dev/null; then
+		CTR_CMD=podman
+	elif command -v docker &>/dev/null; then
+		CTR_CMD=docker
+	else
+		echo "Could not find the podman or docker container runtime."
+		echo "Please install one of them."
+		exit 1
+	fi
+}
+
+setup_volumes() {
+	local selinux_flag
+
+	# Set selinux volume flag if enforcing
+	if command -v getenforce &>/dev/null && [ "$(getenforce 2>/dev/null)" == "Enforcing" ]; then
+		selinux_flag=:z
+	fi
+
+	# Custom source code path(s)
+	for vol in "${!VOL_DIRS[@]}"; do
+		vol_path=${vol}_PATH
+		if [ -n "${!vol_path:-}" ]; then
+			if [ -d "${!vol_path}" ]; then
+				CTR_VOLUME_OPTS+=("-v ${!vol_path}:/workspace/${VOL_DIRS[$vol]}${selinux_flag:-}")
+			else
+				echo "Specified $vol path, $vol_path, does not exist."
+				exit 1
+			fi
+		fi
+	done
+
+	# User management for non-Mac OS's
+	if [ "$(uname -s)" != "Darwin" ] && ! getent passwd "$USER" >/dev/null && [ -n "${USERNAME:-}" ]; then
+		CTR_VOLUME_OPTS+=("-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro")
+	fi
+
+	# Gitconfig
+	if [ -f "${GITCONFIG_PATH:-}" ]; then
+		CTR_VOLUME_OPTS+=("-v ${GITCONFIG_PATH}:/etc/gitconfig${selinux_flag:-}")
+	fi
+}
+
+set_device_opts() {
+	case $TARGET_DEVICE in
+	rocm)
+		CTR_DEVICE_OPTS+=(
+			"--device=/dev/kfd"
+			"--device=/dev/dri"
+		)
+		CTR_SECURITY_OPTS+=(
+			"--cap-add=SYS_PTRACE"
+			"--group-add=render"
+			"--group-add=video"
+			"--ipc=host"
+			"--security-opt seccomp=unconfined"
+		)
+
+		set_env_var ROCM_VERSION "$ROCM_VERSION"
+		set_env_var ROCR_VISIBLE_DEVICES "$ROCR_VISIBLE_DEVICES"
+		IMAGE_TAG=${ROCM_VERSION}-${DEFAULT_IMAGE_TAG}
+		;;
+	cuda)
+		if command -v nvidia-ctk >/dev/null 2>&1 && nvidia-ctk cdi list | grep -q "nvidia.com/gpu=all"; then
+			CTR_DEVICE_OPTS+=("--device nvidia.com/gpu=all")
+		else
+			CTR_DEVICE_OPTS+=("--runtime=nvidia --gpus=all")
+		fi
+
+		CTR_SECURITY_OPTS+=("--security-opt label=disable")
+
+		if [ "${INSTALL_TOOLS:-}" = "true" ]; then
+			CTR_SECURITY_OPTS+=(
+				"--privileged"
+				"--cap-add=SYS_ADMIN"
+			)
+
+			if [ -n "${DISPLAY:-}" ] && [ -n "${WAYLAND_DISPLAY:-}" ]; then
+				set_env_var DISPLAY "$DISPLAY"
+				set_env_var WAYLAND_DISPLAY "$WAYLAND_DISPLAY"
+				set_env_var XDG_RUNTIME_DIR /tmp
+
+				CTR_VOLUME_OPTS+=(
+					"-v ${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:/tmp/${WAYLAND_DISPLAY}:ro"
+				)
+			else
+				echo "WARNING: No DISPLAY or WAYLAND_DISPLAY configured"
+			fi
+		fi
+
+		set_env_var CUDA_VERSION "$CUDA_VERSION"
+		set_env_var CUDA_VISIBLE_DEVICES "$CUDA_VISIBLE_DEVICES"
+		IMAGE_TAG=${CUDA_VERSION}-${DEFAULT_IMAGE_TAG}
+		;;
+	esac
+}
+
+set_user_args() {
+	if [ -z "${USERNAME:-}" ] && [ "$(whoami)" != "root" ]; then
+		USERNAME=$(whoami)
+	fi
+
+	if [ -n "${USERNAME:-}" ] && [ "${USERNAME:-}" != "root" ]; then
+		set_env_var USER "$USERNAME"
+		set_env_var USER_UID "$(id -u "$USER")"
+		set_env_var USER_GID "$(id -g "$USER")"
+	elif [ "$(basename "$CTR_CMD")" = "docker" ]; then
+		CTR_ARGS=(
+			"--user $(id -u):$(id -g)"
+		)
+	elif [ "$(basename "$CTR_CMD")" = "podman" ]; then
+		CTR_ARGS=(
+			"--user $USER"
+		)
+	fi
+}
+
+##
+## MAIN
+##
+
+while getopts "c:d:i:j:k:o:p:rs:t:u:hv" opt; do
+	case "$opt" in
+	c)
+		REMOTE_CONNECTION=$OPTARG
+		;;
+	d)
+		TARGET_DEVICE=$OPTARG
+		;;
+	i)
+		IMAGE="$OPTARG"
+		;;
+	j)
+		MAX_JOBS=$OPTARG
+		;;
+	k)
+		TARGET_STACK=$OPTARG
+		;;
+	o)
+		SUBOPT=${OPTARG/=*/}
+		case "${SUBOPT^^}" in
+		CUDA_VERSION)
+			CUDA_VERSION="${OPTARG/*=/}"
+			;;
+		CUDA_VISIBLE_DEVICES)
+			CUDA_VISIBLE_DEVICES="${OPTARG/*=/}"
+			;;
+		GITCONFIG)
+			GITCONFIG_PATH="${OPTARG/*=/}"
+			;;
+		INSTALL_JUPYTER)
+			INSTALL_JUPYTER="${OPTARG/*=/}"
+			;;
+		INSTALL_TOOLS)
+			set_env_var INSTALL_TOOLS "${OPTARG/*=/}"
+			;;
+		INSTALL_LLVM)
+			set_env_var INSTALL_LLVM "${OPTARG/*=/}"
+			;;
+		INSTALL_HELION)
+			set_env_var INSTALL_HELION "${OPTARG/*=/}"
+			;;
+		INSTALL_TORCH)
+			set_env_var INSTALL_TORCH "${OPTARG/*=/}"
+			;;
+		INSTALL_TRITON)
+			set_env_var INSTALL_TRITON "${OPTARG/*=/}"
+			;;
+		INSTALL_VLLM)
+			set_env_var INSTALL_VLLM "${OPTARG/*=/}"
+			;;
+		PIP_HELION_VERSION)
+			set_env_var PIP_HELION_VERSION "${OPTARG/*=/}"
+			;;
+		PIP_TORCH_INDEX_URL)
+			set_env_var PIP_TORCH_INDEX_URL "${OPTARG/*=/}"
+			;;
+		PIP_TORCH_VERSION)
+			set_env_var PIP_TORCH_VERSION "${OPTARG/*=/}"
+			;;
+		PIP_TRITON_VERSION)
+			set_env_var PIP_TRITON_VERSION "${OPTARG/*=/}"
+			;;
+		PIP_VLLM_COMMIT)
+			set_env_var PIP_VLLM_COMMIT "${OPTARG/*=/}"
+			;;
+		PIP_VLLM_EXTRA_INDEX_URL)
+			set_env_var PIP_VLLM_EXTRA_INDEX_URL "${OPTARG/*=/}"
+			;;
+		PIP_VLLM_VERSION)
+			set_env_var PIP_VLLM_VERSION "${OPTARG/*=/}"
+			;;
+		ROCM_VERSION)
+			ROCM_VERSION="${OPTARG/*=/}"
+			;;
+		ROCR_VISIBLE_DEVICES)
+			ROCR_VISIBLE_DEVICES="${OPTARG/*=/}"
+			;;
+		USE_CCACHE)
+			set_env_var USE_CCACHE "${OPTARG/*=/}"
+			;;
+		UV_TORCH_BACKEND)
+			set_env_var UV_TORCH_BACKEND "${OPTARG/*=/}"
+			;;
+		*)
+			echo "Unknown option ${OPTARG}."
+			exit 1
+			;;
+		esac
+		;;
+	p)
+		INSTALL_JUPYTER=true
+		if [ "${OPTARG^^}" = "AUTO" ]; then
+			JUPYTER_NOTEBOOK_PORT=$DEFAULT_PORT
+		else
+			JUPYTER_NOTEBOOK_PORT=$OPTARG
+		fi
+		;;
+	r)
+		DELETE_ON_EXIT=true
+		;;
+	s)
+		SUBOPT=${OPTARG/=*/}
+		case "${SUBOPT^^}" in
+		LLVM)
+			LLVM_PATH="${OPTARG/*=/}"
+			set_env_var "INSTALL_LLVM" source
+			;;
+		HELION)
+			HELION_PATH="${OPTARG/*=/}"
+			set_env_var "INSTALL_HELION" source
+			;;
+		TORCH)
+			TORCH_PATH="${OPTARG/*=/}"
+			set_env_var "INSTALL_TORCH" source
+			;;
+		TRITON)
+			TRITON_PATH="${OPTARG/*=/}"
+			set_env_var "INSTALL_TRITON" source
+			;;
+		VLLM)
+			VLLM_PATH="${OPTARG/*=/}"
+			set_env_var "INSTALL_VLLM" source
+			;;
+		USER)
+			USER_PATH="${OPTARG/*=/}"
+			;;
+		*)
+			echo "Unknown source path $OPTARG"
+			exit 1
+			;;
+		esac
+		;;
+	t)
+		IMAGE_TAG=$OPTARG
+		;;
+	u)
+		USERNAME=$OPTARG
+		;;
+	h)
+		usage
+		exit 0
+		;;
+	v)
+		set -x
+		;;
+	*)
+		echo "Unknown option $opt."
+		exit 1
+		;;
+	esac
+done
+shift $((OPTIND - 1))
+
+##
+## Command Configuration
+##
+
+# Container Runtime
+set_container_runtime
+
+# Setup Volumes
+setup_volumes
+
+# Device specific arguments (AMD, NVIDIA, etc)
+set_device_opts
+
+# Runtime Arguments
+if [ "$(basename "$CTR_CMD")" = "podman" ]; then
+	CTR_SECURITY_OPTS+=("--userns=keep-id")
+fi
+
+# Jupyter Notebook
+if [ "${INSTALL_JUPYTER:-}" = "true" ]; then
+	CTR_PORT_OPT="-p ${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}:${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}"
+	set_env_var INSTALL_JUPYTER "$INSTALL_JUPYTER"
+	set_env_var NOTEBOOK_PORT "${JUPYTER_NOTEBOOK_PORT:-$DEFAULT_PORT}"
+fi
+
+# Environment Arguments
+set_env_var MAX_JOBS "$MAX_JOBS"
+
+# User args
+set_user_args
+
+# Set stack options
+if [ -n "${TARGET_STACK:-}" ]; then
+	case $TARGET_STACK in
+	helion)
+		set_env_var INSTALL_HELION "source"
+		set_env_var INSTALL_TORCH "release"
+		;;
+	torch)
+		set_env_var INSTALL_TORCH "source"
+		;;
+	triton)
+		set_env_var INSTALL_TORCH "release"
+		set_env_var INSTALL_TRITON "source"
+		;;
+	vllm)
+		set_env_var INSTALL_VLLM "source"
+		;;
+	*)
+		echo "Unknown stack, $TARGET_STACK"
+		exit 1
+		;;
+	esac
+fi
+
+CTR_ARGS+=(
+	"${CTR_ENV_OPTS[@]:-}"
+	"${CTR_DEVICE_OPTS[@]:-}"
+	"${CTR_PORT_OPT:-}"
+	"${CTR_SECURITY_OPTS[@]:-}"
+	"${CTR_VOLUME_OPTS[@]:-}"
+)
+
+if [ -n "${REMOTE_CONNECTION:-}" ]; then
+	CTR_CONNECTION="-r -c $REMOTE_CONNECTION"
+fi
+
+if [ "${DELETE_ON_EXIT:-}" = "true" ]; then
+	CTR_ARGS+=("--rm")
+fi
+
+IMAGE=${IMAGE:-${DEFAULT_IMAGE_REPO}/${TARGET_DEVICE}:${IMAGE_TAG:-${DEFAULT_IMAGE_TAG}}}
+
+printf "Running container image: %s with %s\n" "$IMAGE" "$CTR_CMD"
+printf "%s %s run -ti %s %s bash\n" "$CTR_CMD" "${CTR_CONNECTION:-}" \
+	"${CTR_ARGS[*]}" "$IMAGE"
+$CTR_CMD ${CTR_CONNECTION:-} run -ti ${CTR_ARGS[@]} "${IMAGE}" bash

--- a/triton-dev-containers.sh
+++ b/triton-dev-containers.sh
@@ -149,7 +149,7 @@ Options
         ROCR_VISIBLE_DEVICES         List of AMD device indices or UUIDs (i.e. 0,GPU-DEADBEEFDEADBEEF)
         USE_CCACHE                   Enable ccache [ 0 | 1 ] (Default: ${DEFAULT_ENV_OPTS["USE_CCACHE"]})
         UV_TORCH_BACKEND             Framwork version: [ cu${DEFAULT_ENV_OPTS["CUDA_VERSION"]//-/} | rocm${DEFAULT_ENV_OPTS["ROCM_VERSION"]%.*} | cpu ]
-    -p [ DEFAULT | PORT ]        Expose the specified port for the Jupyter notebook server (Default: $DEFAULT_PORT)
+    -p [ AUTO | PORT ]           Expose the specified port for the Jupyter notebook server (AUTO: $DEFAULT_PORT)
     -r                           Remove the container on exit
     -s SOURCE=PATH               Local source directories to mount as volumes
         GITCONFIG                    /path/to/gitconfig (Default: ${VOL_PATHS["GITCONFIG"]})

--- a/triton-dev-containers.sh
+++ b/triton-dev-containers.sh
@@ -148,7 +148,7 @@ Options
         ROCM_VERSION                 ROCm version (Default: ${DEFAULT_ENV_OPTS["ROCM_VERSION"]})
         ROCR_VISIBLE_DEVICES         List of AMD device indices or UUIDs (i.e. 0,GPU-DEADBEEFDEADBEEF)
         USE_CCACHE                   Enable ccache [ 0 | 1 ] (Default: ${DEFAULT_ENV_OPTS["USE_CCACHE"]})
-        UV_TORCH_BACKEND             Framwork version: [ cu${DEFAULT_ENV_OPTS["CUDA_VERSION"]//-/} | rocm${DEFAULT_ENV_OPTS["ROCM_VERSION"]%.*} | cpu ]
+        UV_TORCH_BACKEND             Framework version: [ cu${DEFAULT_ENV_OPTS["CUDA_VERSION"]//-/} | rocm${DEFAULT_ENV_OPTS["ROCM_VERSION"]%.*} | cpu ]
     -p [ AUTO | PORT ]           Expose the specified port for the Jupyter notebook server (AUTO: $DEFAULT_PORT)
     -r                           Remove the container on exit
     -s SOURCE=PATH               Local source directories to mount as volumes


### PR DESCRIPTION
## Summary

This PR is part 10 of 11 in the rework modernization effort. It adds a CLI wrapper script for easier container management.

**Changes:**
- ✅ Add `triton-dev-containers.sh` CLI tool

**Features:**
- User-friendly command-line interface
- Wraps Makefile run targets with better UX
- Provides help and usage information
- Supports all framework and variant combinations

**Why this change?**

While the Makefile (PR #122) provides powerful functionality, it can be:
- Embedded shell is hard to maintain as it becomes more complex
- Removes requirement to clone the repo just to run a container

The CLI tool addresses this by:
- Moves the runtime shell into an standalone shell script that can be called by the Makefile or a user with no dependencies on anything else in the source

**Example usage:**
```bash
# Run containers
./triton-dev-containers.sh run cuda --triton

# Get help
./triton-dev-containers.sh help
```

**Testing:**
- Works with all variants: cpu, cuda, rocm
- Supports all framework installation options

**Dependencies:**
- Depends on PR #122 (Makefile Modernization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new container launcher with runtime-selectable targets (base, Triton, Helion, Torch, vLLM) for CUDA/ROCm/CPU variants
  * Added install/uninstall targets to place the launcher in the user bin path

* **Changes**
  * Triton installation now defaults to skipped unless enabled
  * GPU device visibility and runtime options are no longer auto-derived and must be explicitly provided
  * Enabling Nsight now forces tools to be installed

* **Bug Fixes**
  * Minor logging message simplified during user setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->