### PR TITLE
docs: update documentation for new architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,25 +89,25 @@ Arguments that can be added to the build commands below, i.e. `OPTION=VALUE`.
 make build-images [OPTIONS]
 ```
 
-#### Base container
+#### Base container build
 
 ```sh
 make base-image [OPTIONS]
 ```
 
-#### NVIDIA CUDA container
+#### NVIDIA CUDA container build
 
 ```sh
 make cuda-image [OPTIONS]
 ```
 
-#### CPU container
+#### CPU container build
 
 ```sh
  make cpu-image [OPTIONS]
 ```
 
-#### AMD ROCm container
+#### AMD ROCm container build
 
 ```sh
  make rocm-image [OPTIONS]
@@ -206,7 +206,8 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 - `USE_CCACHE`
   - Default is `0`, set to `1` to enable the use of CCACHE for builds
 - `UV_TORCH_BACKEND`
-  - Specify the torch backend to install for the `release` target of Triton and vLLM
+  - Specify the torch backend to install for the `release` target of Triton
+    and vLLM
   - CUDA specifies `cu<cuda version>`
   - ROCm specifies `rocm<rocm version>`
   - CPU specifies `cpu`
@@ -217,9 +218,9 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 
 > **_NOTE_**: the `user_path` will be mounted inside the container at `/workspace/user`.
 
-#### NVIDIA CUDA containers
+#### NVIDIA CUDA container runtime
 
-##### CUDA Base
+##### CUDA Base container runtime
 
 ```sh
  make cuda-run [OPTIONS]
@@ -227,100 +228,101 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 
 =======
 
-##### CUDA Triton
+##### CUDA Triton container runtime
 
 ```sh
  make triton-cuda-run [OPTIONS]
 ```
 
-##### CUDA PyTorch
+##### CUDA PyTorch container runtime
 
 ```sh
  make torch-cuda-run [OPTIONS]
 ```
 
-##### CUDA Helion
+##### CUDA Helion container runtime
 
 ```sh
  make helion-cuda-run [OPTIONS]
 ```
 
-##### CUDA vLLM
+##### CUDA vLLM container runtime
 
 ```sh
  make vllm-cuda-run [OPTIONS]
 ```
 
-#### CPU container
+#### CPU container runtime
 
-##### CPU Base
+##### CPU Base container runtime
 
 ```sh
  make cpu-run [OPTIONS]
 ```
 
-##### CPU PyTorch
+##### CPU PyTorch container runtime
 
 ```sh
  make torch-cpu-run [OPTIONS]
 ```
 
-##### CPU Triton
+##### CPU Triton container runtime
 
 ```sh
  make triton-cpu-run [OPTIONS]
 ```
 
-##### CPU Helion
+##### CPU Helion container runtime
 
 ```sh
  make helion-cpu-run [OPTIONS]
 ```
 
-##### CPU vLLM
+##### CPU vLLM container runtime
 
 ```sh
  make vllm-cpu-run [OPTIONS]
 ```
 
-#### AMD ROCm container
+#### AMD ROCm container runtime
 
-##### ROCm Base
+##### ROCm Base container runtime
 
 ```sh
  make rocm-run [OPTIONS]
 ```
 
-##### ROCm Triton
+##### ROCm Triton container runtime
 
 ```sh
  make triton-rocm-run [OPTIONS]
 ```
 
-##### ROCm PyTorch
+##### ROCm PyTorch container runtime
 
 ```sh
  make torch-rocm-run [OPTIONS]
 ```
 
-##### ROCm Helion
+##### ROCm Helion container runtime
 
 ```sh
  make helion-rocm-run [OPTIONS]
 ```
 
-##### ROCm vLLM
+##### ROCm vLLM container runtime
 
 ```sh
  make vllm-rocm-run [OPTIONS]
 ```
 
-> **_NOTE_**: it's also advised that you commit the image after it's completed initialization
-`[podman|docker] commit <container_id> quay.io/triton-dev-containers/[cuda|cpu|rocm]:<image tag>`
+> **_NOTE_**: it's also advised that you commit the image after it's
+  completed initialization
+  `[podman|docker] commit <container_id> quay.io/triton-dev-containers/[cuda|cpu|rocm]:<image tag>`
 
 > **_NOTE_**: if you do provide a triton_path you should run `git submodule init`
-and `git submodule update` on the mounted repo if you haven't already run these
-commands.
+and `git submodule update` on the mounted repo if you haven't already run
+these commands.
 
 ---
 
@@ -363,13 +365,16 @@ The packages installed at startup time can be found in
 
 ## Using the containers as a base for a customized container
 
-Use the `devsetup` script [devsetup.sh](./scripts/devsetup.sh) to run the initial container configuration, like user creation and base software installation.
-It will also run the `devsetup_<framework>` scripts if the `INSTALL_<FRAMEWORK>` variables have been set. By default they are all set to `skip` and won't be run.
+Use the `devsetup` script [devsetup.sh](./scripts/devsetup.sh) to run the
+initial container configuration, like user creation and base software
+installation. It will also run the `devsetup_<framework>` scripts if the
+`INSTALL_<FRAMEWORK>` variables have been set. By default they are all set
+to `skip` and won't be run.
 
-Use the `devsetup_<framework>` scripts to install or setup the container to build
-the target source. Framework refers to triton, helion, torch, llvm, and vllm.
-The scripts can install the wheel packages or download the source and install
-build dependencies.
+Use the `devsetup_<framework>` scripts to install or setup the container to
+build the target source. Framework refers to triton, helion, torch, llvm,
+and vllm. The scripts can install the wheel packages or download the source
+and install build dependencies.
 
 Setup Framework scripts:
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
   - Used to specify the username used inside the container
 
 > **_NOTE_**: the `user_path` will be mounted inside the container at `/workspace/user`.
-  
+
 #### NVIDIA CUDA containers
 
 ##### Base

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ performance counters. Follow this
 
 ### Building
 
-#### Options
+#### Build Options
 
 Arguments that can be added to the build commands below, i.e. `OPTION=VALUE`.
 
@@ -117,7 +117,7 @@ make cuda-image [OPTIONS]
 
 ### Running
 
-#### Options
+#### Runtime Options
 
 Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 
@@ -219,32 +219,33 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 
 #### NVIDIA CUDA containers
 
-##### Base
+##### CUDA Base
 
 ```sh
  make cuda-run [OPTIONS]
 ```
 
 =======
-##### Triton
+
+##### CUDA Triton
 
 ```sh
  make triton-cuda-run [OPTIONS]
 ```
 
-##### PyTorch
+##### CUDA PyTorch
 
 ```sh
  make torch-cuda-run [OPTIONS]
 ```
 
-##### Helion
+##### CUDA Helion
 
 ```sh
  make helion-cuda-run [OPTIONS]
 ```
 
-##### vLLM
+##### CUDA vLLM
 
 ```sh
  make vllm-cuda-run [OPTIONS]
@@ -252,31 +253,31 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 
 #### CPU container
 
-##### Base
+##### CPU Base
 
 ```sh
  make cpu-run [OPTIONS]
 ```
 
-##### PyTorch
+##### CPU PyTorch
 
 ```sh
  make torch-cpu-run [OPTIONS]
 ```
 
-##### Triton
+##### CPU Triton
 
 ```sh
  make triton-cpu-run [OPTIONS]
 ```
 
-##### Helion
+##### CPU Helion
 
 ```sh
  make helion-cpu-run [OPTIONS]
 ```
 
-##### vLLM
+##### CPU vLLM
 
 ```sh
  make vllm-cpu-run [OPTIONS]
@@ -284,31 +285,31 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 
 #### AMD ROCm container
 
-##### Base
+##### ROCm Base
 
 ```sh
  make rocm-run [OPTIONS]
 ```
 
-##### Triton
+##### ROCm Triton
 
 ```sh
  make triton-rocm-run [OPTIONS]
 ```
 
-##### PyTorch
+##### ROCm PyTorch
 
 ```sh
  make torch-rocm-run [OPTIONS]
 ```
 
-##### Helion
+##### ROCm Helion
 
 ```sh
  make helion-rocm-run [OPTIONS]
 ```
 
-##### vLLM
+##### ROCm vLLM
 
 ```sh
  make vllm-rocm-run [OPTIONS]

--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
 
 > **_NOTE_**: it's also advised that you commit the image after it's
   completed initialization
-  `[podman|docker] commit <container_id> quay.io/triton-dev-containers/[cuda|cpu|rocm]:<image tag>`
+  `[podman|docker] commit <container_id>
+  quay.io/triton-dev-containers/[cuda|cpu|rocm]:<image tag>`
 
 > **_NOTE_**: if you do provide a triton_path you should run `git submodule init`
 and `git submodule update` on the mounted repo if you haven't already run

--- a/README.md
+++ b/README.md
@@ -2,27 +2,26 @@
 
 ## TL;DR
 
-- **What this repo provides**: Preconfigured development containers
-for building and running Triton and Triton-cpu.
-- **Who it's for**: Developers working on Triton.
+- **What this repo provides**: Preconfigured development containers for
+building and running Triton, Triton-cpu, PyTorch, Helion and vLLM.
+- **Who it's for**: Developers working on Triton, PyTorch, Helion and vLLM.
 - **Why use it**: Provides isolated, reproducible environments for
 development.
-- **How to use it**: Mount your Triton directory into the available
-containers and start working.
+- **How to use it**: Mount your Triton, PyTorch, Helion and/or vLLM
+source directory into the available containers and start working.
 
 ---
 
 ## Details
 
-This repository provides development containers preconfigured with
-all the necessary tools to build and run Triton and Triton-cpu.
-By mounting your Triton directory from the host into the container,
-you can continue working with your preferred IDE while keeping build
-and runtime tasks isolated within the container environment. This
-repo also provides the .devcontainer files that can be used with
-the VSCode development container extension. The goal of this repo
-is to provide consistent and reproducible development environments
-for Triton.
+This repository provides development containers preconfigured with all the
+necessary tools to build and run Triton, Triton-cpu, PyTorch, Helion and/or
+vLLM. By mounting your source directory from the host into the container,
+you can continue working with your preferred IDE while keeping build and
+runtime tasks isolated within the container environment. This repo also
+provides the .devcontainer files that can be used with the VSCode
+development container extension. The goal of this repo is to provide
+consistent and reproducible development environments for Triton.
 
 ### Available Containers
 
@@ -44,19 +43,12 @@ Before using these containers, ensure you have the following installed:
 
 > **Note:** If using an NVIDIA GPU, install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
-> **Note:** The NVIDIA Container Toolkit is not required for `triton-cpu`.
-
 > **Note:** If using an AMD GPU, install the
 [ROCm Docker Prerequisites](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html).
 
-> **Note:** To install the NVIDIA NSight profiling tools, the host system needs
-to have an active Red Hat subscription. A free subscription can be acquired from
-the Red Hat Developer website.
-[Red Hat Developer: Register](https://developers.redhat.com/register)
-
-> **Note:** If using a 'rootless' triton container, the NVIDIA NSight Compute
-application will not work without enabling access to the NVIDIA GPU performance
-counters. Follow this
+> **Note:** If using a 'rootless' container, the NVIDIA NSight Compute
+application will not work without enabling access to the NVIDIA GPU
+performance counters. Follow this
 [NVIDIA Development Tools Solution](https://developer.nvidia.com/nvidia-development-tools-solutions-err_nvgpuctrperm-permission-issue-performance-counters)
 
 ### Supported Hardware
@@ -65,83 +57,279 @@ counters. Follow this
 - AMD GPUs
 - CPUs
 
-### Using Vanilla Containers
+---
 
-#### Building the triton NVIDIA vanilla container
+## Vanilla Containers
+
+---
+
+### Building
+
+#### Options
+
+Arguments that can be added to the build commands below, i.e. `OPTION=VALUE`.
+
+- `CENTOS_VERSION`
+  - CentOS Stream image version to use, i.e. `9`
+- `CUDA_VERSION`
+  - Use the CUDA RPM package version, i.e. `12-9`
+- `GOSU_VERSION`
+  - Check the gosu GitHub for the desired release
+  - <https://github.com/tianon/gosu>
+- `PYTHON_VERSION`
+  - Use the desired RPM package version, i.e. `3.12`
+- `ROCM_VERSION`
+  - Use the ROCm RPM package version, i.e. `7.1.1`
+- `ROCM_RHEL_VERSION`
+  - Use the ROCm RPM package for specified RHEL version, i.e. `9.7`
+
+#### All of the container images
 
 ```sh
-make triton-image
+make build-images [OPTIONS]
 ```
 
-#### Running the triton NVIDIA vanilla container
+#### Base container
 
 ```sh
- make triton-run [triton_path=<path-to-triton-on-host> user_path=<path-to-user-workspace> INSTALL_NSIGHT=true]
+make base-image [OPTIONS]
 ```
 
-> **_NOTE_**: if you do not provide `triton_path` the triton repo will be cloned
-at container startup time.
+#### NVIDIA CUDA container
 
-> **_NOTE_**: if you do provide a triton_path you should run `git submodule init`
-and `git submodule update` on the mounted repo if you haven't already run these
-commands.
+```sh
+make cuda-image [OPTIONS]
+```
+
+#### CPU container
+
+```sh
+ make cpu-image [OPTIONS]
+```
+
+#### AMD ROCm container
+
+```sh
+ make rocm-image [OPTIONS]
+```
+
+---
+
+### Running
+
+#### Options
+
+Arguments that can be added to the run commands below, i.e. `OPTION=VALUE`.
+
+- `CUDA_VERSION`
+  - Use the CUDA RPM package version, i.e. `12-9`
+  - Specifies the CUDA image to use
+- `ROCM_VERSION`
+  - Specifies the ROCm image to use
+  - Use the ROCm RPM package version, i.e. `6.3.4`
+- `CENTOS_VERSION`
+  - CentOS Stream image version to use
+- `MAX_JOBS`
+  - Number of cores to use when building Triton, PyTorch, Helion or vLLM
+  - Default is the `nproc --all`
+  - NOTE: Use a lower value if builds cause the host to run out of memory
+- `CUDA_VISIBLE_DEVICES`
+  - Used to specify the CUDA device index(s) to use, i.e. `0,1`
+- `ROCR_VISIBLE_DEVICES`
+  - Used to specify the ROCm device index(s) or UUID(s) to use, i.e. `0,GPU-<UUID>`
+- `NOTEBOOK_PORT`
+  - HTTP port to expose and use for the Jupyter notebook server
+- `INSTALL_TOOLS`
+  - Install extra tools, such as profiling tools like NVIDIA's Nsight
+- `INSTALL_JUPYTER`
+  - Enabled by default, so set to `false` to not install the server
+- `INSTALL_LLVM`
+  - Default is to `skip`
+  - Set to `source` to install build deps and download the source if not
+      passed in as a volume using `llvm_path=/path/to/source`
+- `INSTALL_HELION`
+  - Default is to `skip`
+  - Set to `source` to install build deps and download the source if not
+      passed in as a volume using `helion_path=/path/to/source`
+  - Set to `release` or `nightly` to install the wheel
+- `INSTALL_TRITON`
+  - Default is to `skip`
+  - Set to `source` to install build deps and download the source if not
+      passed in as a volume using `triton_path=/path/to/source`
+  - Set to `release` to install the wheel
+- `INSTALL_TORCH`
+  - Default is to `skip`
+  - Set to `source` to install build deps and download the source if not
+      passed in as a volume using `torch_path=/path/to/source`
+  - Set to `release`, `nightly`, `test` to install the wheel
+- `INSTALL_VLLM`
+  - Default is to `skip`
+  - Set to `source` to install build deps and download the source if not
+      passed in as a volume using `vllm_path=/path/to/source`
+  - Set to `release` or `nightly` to install the wheel
+- `llvm_path`
+  - Local path to LLVM project source to be mounted at `/workspace/llvm-project`
+      within the container
+- `helion_path`
+  - Local path to Helion source to be mounted at `/workspace/helion` within
+      the container
+- `triton_path`
+  - Local path to Triton source to be mounted at `/workspace/triton` within
+      the container
+- `torch_path`
+  - Local path to PyTorch source to be mounted at `/workspace/torch` within
+      the container
+- `vllm_path`
+  - Local path to vLLM source to be mounted at `/workspace/vllm` within
+      the container
+- `user_path`
+  - General use option to mount a host path into the container at
+      `/workspace/user`
+- `PIP_TORCH_VERSION`
+  - Specify the wheel version to install, i.e. `torch==<version>`
+- `PIP_HELION_VERSION`
+  - Specify the wheel version to install, i.e. `helion==<version>`
+- `PIP_TRITON_VERSION`
+  - Specify the wheel version to install, i.e. `triton==<version>`
+- `PIP_VLLM_VERSION`
+  - Specify the wheel version to install, i.e. `vllm==<version>`
+- `gitconfig_path`
+  - Default is `~/.gitconfig`, use to specify a different gitconfig file path
+- `PIP_TORCH_INDEX_URL`
+  - Default is `https://download.pytorch.org/whl`
+  - Specify a URL to install the torch wheel from
+- `PIP_VLLM_EXTRA_INDEX_URL`
+  - Same as the torch index url above except for the vLLM wheels
+- `PIP_VLLM_COMMIT`
+  - vLLM's default index url can install specific git commit builds, specify
+      the commit hash you would like to install here
+- `USE_CCACHE`
+  - Default is `0`, set to `1` to enable the use of CCACHE for builds
+- `UV_TORCH_BACKEND`
+  - Specify the torch backend to install for the `release` target of Triton and vLLM
+  - CUDA specifies `cu<cuda version>`
+  - ROCm specifies `rocm<rocm version>`
+  - CPU specifies `cpu`
+  - Can use `auto` to let `uv` select the appropriate backend
+- `create_user`
+  - Default is the host username
+  - Used to specify the username used inside the container
 
 > **_NOTE_**: the `user_path` will be mounted inside the container at `/workspace/user`.
+  
+#### NVIDIA CUDA containers
 
-> **_NOTE_**: if you provide `INSTALL_NSIGHT=true` the NVIDIA NSight profiling
-tools will be installed. This requires the host system to have an active
-Red Hat subscription.
-
-#### Building the triton-cpu vanilla container
+##### Base
 
 ```sh
- make triton-cpu-image
+ make cuda-run [OPTIONS]
 ```
 
-#### Running the triton-cpu vanilla container
+=======
+##### Triton
 
 ```sh
- make triton-cpu-run [triton_path=<path-to-triton-on-host> user_path=<path-to-user-workspace>]
+ make triton-cuda-run [OPTIONS]
 ```
 
-> **_NOTE_**: if you do not provide `triton_path` the triton-cpu repo will be cloned
-at container startup time.
-
-> **_NOTE_**: if you do provide a triton_path you should run `git submodule init`
-and `git submodule update` on the mounted repo if you haven't already run these
-commands.
-
-> **_NOTE_**: the `user_path` will be mounted inside the container at `/workspace/user`.
-
-#### Building the triton-amd vanilla container
+##### PyTorch
 
 ```sh
- make triton-amd-image
+ make torch-cuda-run [OPTIONS]
 ```
 
-#### Running the triton-amd vanilla container
+##### Helion
 
 ```sh
- make triton-amd-run [triton_path=<path-to-triton-on-host> user_path=<path-to-user-workspace>]
+ make helion-cuda-run [OPTIONS]
 ```
 
-> **_NOTE_**: if you do not provide `triton_path` the triton repo will be cloned
-at container startup time.
+##### vLLM
+
+```sh
+ make vllm-cuda-run [OPTIONS]
+```
+
+#### CPU container
+
+##### Base
+
+```sh
+ make cpu-run [OPTIONS]
+```
+
+##### PyTorch
+
+```sh
+ make torch-cpu-run [OPTIONS]
+```
+
+##### Triton
+
+```sh
+ make triton-cpu-run [OPTIONS]
+```
+
+##### Helion
+
+```sh
+ make helion-cpu-run [OPTIONS]
+```
+
+##### vLLM
+
+```sh
+ make vllm-cpu-run [OPTIONS]
+```
+
+#### AMD ROCm container
+
+##### Base
+
+```sh
+ make rocm-run [OPTIONS]
+```
+
+##### Triton
+
+```sh
+ make triton-rocm-run [OPTIONS]
+```
+
+##### PyTorch
+
+```sh
+ make torch-rocm-run [OPTIONS]
+```
+
+##### Helion
+
+```sh
+ make helion-rocm-run [OPTIONS]
+```
+
+##### vLLM
+
+```sh
+ make vllm-rocm-run [OPTIONS]
+```
 
 > **_NOTE_**: it's also advised that you commit the image after it's completed initialization
-`[podman|docker] commit <container_id> quay.io/triton-dev-containers/amd:latest`
+`[podman|docker] commit <container_id> quay.io/triton-dev-containers/[cuda|cpu|rocm]:<image tag>`
 
 > **_NOTE_**: if you do provide a triton_path you should run `git submodule init`
 and `git submodule update` on the mounted repo if you haven't already run these
 commands.
 
-> **_NOTE_**: the `user_path` will be mounted inside the container at `/workspace/user`.
+---
 
-### Using .devcontainers with VSCODE
+## Using .devcontainers with VSCODE
 
 Please see the [.devcontainer user guide](./.devcontainer/devcontainer.md)
 
-### Demos
+---
+
+## Demos
 
 To see the VSCODE devcontainers in action please check out the
 [Triton devcontainer vscode demo](https://www.youtube.com/watch?v=ZrCVtV2Bw3s)
@@ -149,42 +337,43 @@ To see the VSCODE devcontainers in action please check out the
 To see the vanilla development containers in action please checkout the
 [Triton devcontainer demo](https://www.youtube.com/watch?v=kEbN6-pk3sI)
 
-### Why Container-First Development Matters?
+## Why Container-First Development Matters?
 
 Please checkout [why container-first development matters](./docs/ContainerFirstDevelopment.md).
 
-### More about the containers
+## More about the containers
 
 The container images provided by this repo are based on
 [RHEL UBI images](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image).
 They support both root and non-root users. For non-root
 user support, the user is created at runtime via the container
-entrypoint script [entrypoint.sh](./entrypoint.sh).
+`devcreate_user` script [devcreate_user.sh](./scripts/devcreate_user.sh).
 
-### Adding packages as a non-root user inside the development containers
+To install additional software, `sudo` has been added and the user given
+non-passworded usage of it.
 
-To add extra packages to the non-root user container, create a
-Dockerfile that extends one of the provided base/vanilla
-images:
-
-- quay.io/triton-dev-containers/nvidia
-- quay.io/triton-dev-containers/cpu
-- quay.io/triton-dev-containers/amd
-
-```dockerfile
-FROM quay.io/triton-dev-containers/nvidia:latest
-
-USER 0
-
-RUN dnf update -y && \
-    dnf -y install <PACKAGES> && \ #### <==== modify this line to add your packages.
-    dnf clean all
-```
-
-### Why do the containers install some dependencies at startup time?
+## Why do the containers install some dependencies at startup time?
 
 Some dependencies are installed at runtime to optimize image size of
 the development containers. This allows the images to remain
 lightweight while still providing all necessary functionality.
 The packages installed at startup time can be found in
-[entrypoint.sh](./entrypoint.sh).
+[devinstall_software.sh](./scripts/devinstall_software.sh).
+
+## Using the containers as a base for a customized container
+
+Use the `devsetup` script [devsetup.sh](./scripts/devsetup.sh) to run the initial container configuration, like user creation and base software installation.
+It will also run the `devsetup_<framework>` scripts if the `INSTALL_<FRAMEWORK>` variables have been set. By default they are all set to `skip` and won't be run.
+
+Use the `devsetup_<framework>` scripts to install or setup the container to build
+the target source. Framework refers to triton, helion, torch, llvm, and vllm.
+The scripts can install the wheel packages or download the source and install
+build dependencies.
+
+Setup Framework scripts:
+
+- [devinstall_helion.sh](./scripts/devinstall_helion.sh)
+- [devinstall_llvm.sh](./scripts/devinstall_llvm.sh)
+- [devinstall_torch.sh](./scripts/devinstall_torch.sh)
+- [devinstall_triton.sh](./scripts/devinstall_triton.sh)
+- [devinstall_vllm.sh](./scripts/devinstall_vllm.sh)


### PR DESCRIPTION
## Summary

This PR is part 11 of 11 in the rework modernization effort. It updates all documentation to reflect the new architecture and features.

**Changes:**
- ✅ Update `README.md` for new architecture

**README.md updates:**
- New image naming (cpu, cuda, rocm vs triton-*)
- Document INSTALL_* environment variables for all frameworks
- Updated build and run command examples
- New Makefile targets and options
- Information about modular setup scripts
- Improved organization and clarity

**Why this change?**

After all the architectural changes in PRs #115-124, the documentation
needs to be updated to:
- Accurately reflect the new structure
- Help users understand new features and options
- Provide clear examples of the new commands
- Ensure consistency between code and docs

**Testing:**
- Documentation reviewed for accuracy
- All examples verified against new Makefile targets
- Links and references checked

**Dependencies:**
- Depends on all previous PRs (#115-124)
- Should be merged last to ensure docs match final state

**Completes:**
This is the final PR in the 11-part rework modernization series.
Once merged (along with all dependencies), the rework will be complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README to document support for PyTorch, Helion, and vLLM alongside Triton.
  * Added coverage for NVIDIA CUDA, CPU, and AMD ROCm hardware backends.
  * Reorganized container building and running instructions with dedicated subsections.
  * Documented explicit make targets for each framework-hardware combination.
  * Added detailed configuration options and updated container startup process documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->