### PR TITLE
Fixing minor commands and dead code removal

### DIFF
--- a/.devcontainer/devcontainer.md
+++ b/.devcontainer/devcontainer.md
@@ -90,7 +90,7 @@ This option clones the entire `triton-dev-containers` repository.
 ```bash
 git clone https://github.com/redhat-et/triton-dev-containers.git
 cd triton-dev-containers
-make devcontainers
+make -C .devcontainer generate
 ```
 
 ### Launch VSCode Dev Container

--- a/.github/workflows/cpu-image.yml
+++ b/.github/workflows/cpu-image.yml
@@ -44,8 +44,6 @@ jobs:
       image-name: cpu
       image-tag: centos9
       dockerfile: dockerfiles/Dockerfile.cpu
-      build-args: |
-        USERNAME=triton
       platforms: linux/amd64
     secrets:
       qt_username: ${{ secrets.qt_username }}

--- a/.github/workflows/cuda-image.yml
+++ b/.github/workflows/cuda-image.yml
@@ -45,7 +45,6 @@ jobs:
       image-tag: 12-9-centos9
       dockerfile: dockerfiles/Dockerfile.cuda
       build-args: |
-        USERNAME=triton
         BUILD_CUDA_VERSION=12-9
       platforms: linux/amd64
     secrets:

--- a/.github/workflows/rocm-image.yml
+++ b/.github/workflows/rocm-image.yml
@@ -45,7 +45,6 @@ jobs:
       image-tag: 7.1.1-centos9
       dockerfile: dockerfiles/Dockerfile.rocm
       build-args: |
-        USERNAME=triton
         BUILD_ROCM_VERSION=7.1.1
         BUILD_ROCM_RHEL_VERSION=9.7
       platforms: linux/amd64

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,6 +5,3 @@ rules:
   document-start: disable
   comments:
     min-spaces-from-content: 1
-ignore:
-  - builddir/*
-  - .clang-format

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ IMAGE_REPO = quay.io/triton-dev-containers
 BASE_IMAGE_NAME = base
 CPU_IMAGE_NAME  = cpu
 CUDA_IMAGE_NAME = cuda
-GOSU_IMAGE_NAME = gosu
 ROCM_IMAGE_NAME = rocm
 
 # Image tags
@@ -59,13 +58,11 @@ IMAGE_TAG      := centos$(CENTOS_VERSION)
 BASE_IMAGE_TAG := $(IMAGE_TAG)
 CPU_IMAGE_TAG  := $(IMAGE_TAG)
 CUDA_IMAGE_TAG := $(CUDA_VERSION)-$(IMAGE_TAG)
-GOSU_IMAGE_TAG := $(GOSU_VERSION)-$(IMAGE_TAG)
 ROCM_IMAGE_TAG := $(ROCM_VERSION)-$(IMAGE_TAG)
 
 # ------------------------------------------------------------------------------
 # Runtime configuration
 # ------------------------------------------------------------------------------
-RUNTIME_ARGS ?=
 
 # Set the max number of jobs to use when building a framework
 # Use a lower value to decrease ram usage during a build
@@ -137,16 +134,6 @@ define build-image
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(1):$(2) \
 		$(3) -f $(4) .
 endef
-
-# Old build targets (DEPRECATED)
-.PHONY: triton-image
-triton-image: cuda-image
-
-.PHONY: triton-cpu-image
-triton-cpu-image: cpu-image
-
-.PHONY: triton-amd-image
-triton-amd-image: rocm-image
 
 .PHONY: build-images
 build-images: cuda-image cpu-image rocm-image ## Build all container images
@@ -286,15 +273,6 @@ define ROCM_RUNTIME_ARGS
 	$(RUNTIME_ARGS) \
 	-o ROCM_VERSION=$(ROCM_VERSION)
 endef
-
-
-# Old runtime targets (DEPRECATED)
-.PHONY: triton-run
-triton-run: triton-cuda-run
-
-.PHONY: triton-amd-run
-triton-amd-run: triton-rocm-run
-
 
 .PHONY: base-run
 base-run: ## Run the Base container image

--- a/README.md
+++ b/README.md
@@ -366,11 +366,11 @@ The packages installed at startup time can be found in
 
 Use the `devsetup` script [devsetup.sh](./scripts/devsetup.sh) to run the
 initial container configuration, like user creation and base software
-installation. It will also run the `devsetup_<framework>` scripts if the
+installation. It will also run the `devinstall_<framework>` scripts if the
 `INSTALL_<FRAMEWORK>` variables have been set. By default they are all set
 to `skip` and won't be run.
 
-Use the `devsetup_<framework>` scripts to install or setup the container to
+Use the `devinstall_<framework>` scripts to install or setup the container to
 build the target source. Framework refers to triton, helion, torch, llvm,
 and vllm. The scripts can install the wheel packages or download the source
 and install build dependencies.

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CENTOS_VERSION=10
+ARG CENTOS_VERSION=9
 FROM quay.io/centos/centos:stream${CENTOS_VERSION}-minimal AS gosu
 
 USER 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated Make targets for triton image builds and container execution
  * Removed deprecated gosu image references
  * Updated linting configuration

* **Documentation**
  * Clarified devsetup script behavior in README

* **Configuration**
  * Changed default CentOS version from 10 to 9 for container builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->