### PR TITLE
Fix for MAX_JOBS: unbound variable error when asking for script help

### DIFF
--- a/triton-dev-containers.sh
+++ b/triton-dev-containers.sh
@@ -118,7 +118,7 @@ Options
     -c REMOTE_CONNECTION         Use the remote podman system
     -d DEVICE                    Target device [ base | cpu | cuda | rocm ] (Default: $TARGET_DEVICE)
     -i IMAGE                     Image (Default: $DEFAULT_IMAGE)
-    -j MAX_JOBS                  Maximum number of jobs to use when building Triton/Helion/PyTorch/vLLM (Default: $MAX_JOBS)
+    -j MAX_JOBS                  Maximum number of jobs to use when building Triton/Helion/PyTorch/vLLM (Default: ${DEFAULT_ENV_OPTS["MAX_JOBS"]})
     -k TARGET_STACK              Target stack [ helion | torch | triton | vllm ]
     -o OPTION=ARGUMENT           Specify a argument for an option
         CUDA_VERSION                 CUDA version (Default: ${DEFAULT_ENV_OPTS["CUDA_VERSION"]})


### PR DESCRIPTION
Hit a bug due not moving the MAX_JOBS variable to the DEFAULT_ENV_OPTS in the usage printout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the help text for the `-j MAX_JOBS` option to display the correct default value, improving clarity when users review available command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->